### PR TITLE
Fixes page: add Recent sub-tab with newly published fixes feed

### DIFF
--- a/src/LuaToolsGui/Models/FixModels.cs
+++ b/src/LuaToolsGui/Models/FixModels.cs
@@ -56,3 +56,36 @@ public class DenuvoDownloadResponse
 {
     [JsonPropertyName("url")] public string Url { get; set; } = "";
 }
+
+// ── Supabase REST (direct, anon) — the recently-added fixes feed ─────
+// There's no /api/denuvo "recent" endpoint, so the Fixes page's "Recent" tab reads the public
+// `denuvo_fixes` table straight from PostgREST (same pattern as GetStandardUsageAsync reading
+// `user_downloads`). Each row comes with its game and tags embedded.
+
+public class DenuvoRecentFix
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = "";
+    [JsonPropertyName("appid")] public string AppId { get; set; } = "";
+    [JsonPropertyName("title")] public string Title { get; set; } = "";
+    [JsonPropertyName("description")] public string? Description { get; set; }
+    [JsonPropertyName("created_at")] public string? CreatedAt { get; set; }
+    [JsonPropertyName("denuvo_games")] public DenuvoRecentGame? Game { get; set; }
+    [JsonPropertyName("denuvo_fix_tags")] public List<DenuvoRecentFixTag> FixTags { get; set; } = [];
+
+    /// <summary>The fix's tags, flattened from the denuvo_fix_tags → denuvo_tags embed.</summary>
+    [JsonIgnore]
+    public IReadOnlyList<DenuvoTag> Tags =>
+        FixTags.Where(t => t.Tag is not null).Select(t => t.Tag!).ToList();
+}
+
+public class DenuvoRecentGame
+{
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("header_image")] public string? HeaderImage { get; set; }
+}
+
+public class DenuvoRecentFixTag
+{
+    [JsonPropertyName("tag_id")] public string TagId { get; set; } = "";
+    [JsonPropertyName("denuvo_tags")] public DenuvoTag? Tag { get; set; }
+}

--- a/src/LuaToolsGui/Resources/Strings.Designer.cs
+++ b/src/LuaToolsGui/Resources/Strings.Designer.cs
@@ -301,6 +301,11 @@ public static class Strings
     public static string Fixes_Toast_CouldntApply => Get(nameof(Fixes_Toast_CouldntApply));
     public static string Fixes_Toast_Refreshed_Title => Get(nameof(Fixes_Toast_Refreshed_Title));
     public static string Fixes_Toast_Refreshed_Body => Get(nameof(Fixes_Toast_Refreshed_Body));
+    public static string Fixes_Tab_Games => Get(nameof(Fixes_Tab_Games));
+    public static string Fixes_Tab_Recent => Get(nameof(Fixes_Tab_Recent));
+    public static string Fixes_New => Get(nameof(Fixes_New));
+    public static string Fixes_Recent_Empty => Get(nameof(Fixes_Recent_Empty));
+    public static string Fixes_Recent_Err_Load => Get(nameof(Fixes_Recent_Err_Load));
 
     // ── Add / Download ──
     public static string Add_Title => Get(nameof(Add_Title));

--- a/src/LuaToolsGui/Resources/Strings.ar.resx
+++ b/src/LuaToolsGui/Resources/Strings.ar.resx
@@ -553,4 +553,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>لقد بلغت حدّك اليومي في Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>لا يوجد بيان Hubcap متاح لهذا التطبيق.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>فشل التنزيل من Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>ألعاب</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>الأحدث</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>جديد</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>لا توجد إصلاحات صدرت مؤخرًا.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>تعذّر تحميل الإصلاحات الحديثة. تحقق من اتصالك.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.bg.resx
+++ b/src/LuaToolsGui/Resources/Strings.bg.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Достигна дневния си лимит за Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Няма наличен Hubcap манифест за това приложение.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Изтеглянето от Hubcap е неуспешно ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Игри</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Скорошни</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Ново</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Наскоро не са излизали корекции.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Скорошните корекции не можаха да се заредят. Проверете връзката си.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.cs.resx
+++ b/src/LuaToolsGui/Resources/Strings.cs.resx
@@ -527,4 +527,9 @@ Tím se smažou soubory .lua ze Steam\config\stplug-in. Poté restartujte Steam,
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Dosáhl jsi denního limitu Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Pro tuto aplikaci není dostupný žádný manifest Hubcap.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Stahování z Hubcap selhalo ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Hry</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Nedávné</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nové</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Žádné nedávné opravy.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Nedávné opravy se nepodařilo načíst. Zkontrolujte připojení.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.da.resx
+++ b/src/LuaToolsGui/Resources/Strings.da.resx
@@ -527,4 +527,9 @@ Dette sletter .lua-filerne fra Steam\config\stplug-in. Genstart Steam bagefter, 
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Du har nået din daglige Hubcap-grænse.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Der er ingen Hubcap-manifest til denne app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-download mislykkedes ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Spil</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Seneste</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Ny</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Ingen nylige rettelser.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Kunne ikke indlæse nylige rettelser. Tjek din forbindelse.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.de.resx
+++ b/src/LuaToolsGui/Resources/Strings.de.resx
@@ -527,4 +527,9 @@ Dadurch werden die .lua-Dateien aus Steam\config\stplug-in gelöscht. Starte Ste
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Dein tägliches Hubcap-Limit ist erreicht.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Für diese App ist kein Hubcap-Manifest verfügbar.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-Download fehlgeschlagen ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Spiele</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Neueste</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Neu</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Noch keine neuen Fixes.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Neue Fixes konnten nicht geladen werden. Überprüfe deine Verbindung.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.el.resx
+++ b/src/LuaToolsGui/Resources/Strings.el.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Έφτασες το ημερήσιο όριο του Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Δεν υπάρχει διαθέσιμο manifest Hubcap για αυτήν την εφαρμογή.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Η λήψη από το Hubcap απέτυχε ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Παιχνίδια</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Πρόσφατα</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Νέο</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Δεν κυκλοφόρησαν πρόσφατες διορθώσεις.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Δεν ήταν δυνατή η φόρτωση των πρόσφατων διορθώσεων. Ελέγξτε τη σύνδεσή σας.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.es-419.resx
+++ b/src/LuaToolsGui/Resources/Strings.es-419.resx
@@ -527,4 +527,9 @@ Esto borra los archivos .lua de Steam\config\stplug-in. Reinicia Steam después 
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Llegaste a tu límite diario de Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>No hay ningún manifiesto de Hubcap para esta app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Falló la descarga de Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Juegos</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recientes</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nuevo</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>No hay parches publicados recientemente.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>No se pudieron cargar los parches recientes. Comprueba tu conexión.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.es.resx
+++ b/src/LuaToolsGui/Resources/Strings.es.resx
@@ -527,4 +527,9 @@ Esto borra los archivos .lua de Steam\config\stplug-in. Reinicia Steam después 
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Has alcanzado tu límite diario de Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>No hay ningún manifiesto de Hubcap para esta app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Error en la descarga de Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Juegos</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recientes</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nuevo</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>No hay parches publicados recientemente.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>No se pudieron cargar los parches recientes. Comprueba tu conexión.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.fi.resx
+++ b/src/LuaToolsGui/Resources/Strings.fi.resx
@@ -527,4 +527,9 @@ Tämä poistaa .lua-tiedostot sijainnista Steam\config\stplug-in. Käynnistä St
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Päivittäinen Hubcap-rajasi on täynnä.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Tälle sovellukselle ei ole Hubcap-manifestia.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-lataus epäonnistui ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Pelit</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Uusimmat</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Uusi</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Ei viimeaikaisia korjauksia.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Uusimpia korjauksia ei voitu ladata. Tarkista yhteytesi.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.fr.resx
+++ b/src/LuaToolsGui/Resources/Strings.fr.resx
@@ -527,4 +527,9 @@ Cela supprime les fichiers .lua de Steam\config\stplug-in. Redémarrez Steam ens
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Ta limite quotidienne Hubcap est atteinte.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Aucun manifeste Hubcap n'est disponible pour cette app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Échec du téléchargement Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Jeux</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Récents</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nouveau</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Aucun correctif publié récemment.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Impossible de charger les correctifs récents. Vérifiez votre connexion.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.hu.resx
+++ b/src/LuaToolsGui/Resources/Strings.hu.resx
@@ -527,4 +527,9 @@ Ez törli a .lua fájlokat a Steam\config\stplug-in mappából. Ezután indítsd
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Elérted a napi Hubcap-korlátot.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Ehhez az alkalmazáshoz nincs Hubcap-manifeszt.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>A Hubcap-letöltés sikertelen ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Játékok</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Legutóbbiak</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Új</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Nincs mostanában megjelent javítás.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>A legutóbbi javítások betöltése nem sikerült. Ellenőrizd a kapcsolatot.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.id.resx
+++ b/src/LuaToolsGui/Resources/Strings.id.resx
@@ -527,4 +527,9 @@ Ini menghapus file .lua dari Steam\config\stplug-in. Mulai ulang Steam setelahny
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Kamu sudah mencapai batas harian Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Tidak ada manifes Hubcap untuk aplikasi ini.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Unduhan Hubcap gagal ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Game</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Terbaru</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Baru</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Belum ada perbaikan yang dirilis baru-baru ini.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Tidak dapat memuat perbaikan terbaru. Periksa koneksi Anda.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.it.resx
+++ b/src/LuaToolsGui/Resources/Strings.it.resx
@@ -527,4 +527,9 @@ Questo elimina i file .lua da Steam\config\stplug-in. Riavvia Steam in seguito a
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Hai raggiunto il limite giornaliero di Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Nessun manifest Hubcap disponibile per questa app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Download da Hubcap non riuscito ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Giochi</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recenti</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nuovo</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Nessun fix pubblicato di recente.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Impossibile caricare i fix recenti. Controlla la connessione.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ja.resx
+++ b/src/LuaToolsGui/Resources/Strings.ja.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Hubcap の 1 日の上限に達しました。</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>このアプリ用の Hubcap マニフェストはありません。</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap からのダウンロードに失敗しました ({0})。</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>ゲーム</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>最近</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>新着</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>最近公開された修正はありません。</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>最近の修正を読み込めませんでした。接続を確認してください。</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ko.resx
+++ b/src/LuaToolsGui/Resources/Strings.ko.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>일일 Hubcap 한도에 도달했습니다.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>이 앱에 사용할 수 있는 Hubcap 매니페스트가 없습니다.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap 다운로드 실패 ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>게임</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>최근</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>새 항목</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>최근에 출시된 수정이 없습니다.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>최근 수정을 불러올 수 없습니다. 연결을 확인하세요.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.nb.resx
+++ b/src/LuaToolsGui/Resources/Strings.nb.resx
@@ -527,4 +527,9 @@ Dette sletter .lua-filene fra Steam\config\stplug-in. Start Steam på nytt etter
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Du har nådd den daglige Hubcap-grensen.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Det finnes ingen Hubcap-manifest for denne appen.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-nedlastingen mislyktes ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Spill</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Nylige</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Ny</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Ingen nylige fikser.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Kunne ikke laste nylige fikser. Sjekk tilkoblingen din.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.nl.resx
+++ b/src/LuaToolsGui/Resources/Strings.nl.resx
@@ -527,4 +527,9 @@ Dit verwijdert de .lua-bestanden uit Steam\config\stplug-in. Herstart Steam daar
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Je dagelijkse Hubcap-limiet is bereikt.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Er is geen Hubcap-manifest voor deze app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-download mislukt ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Games</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recent</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nieuw</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Geen recente fixes.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Kon recente fixes niet laden. Controleer je verbinding.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pl.resx
+++ b/src/LuaToolsGui/Resources/Strings.pl.resx
@@ -527,4 +527,9 @@ Spowoduje to usunięcie plików .lua z Steam\config\stplug-in. Następnie urucho
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Osiągnięto dzienny limit Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Brak manifestu Hubcap dla tej aplikacji.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Pobieranie z Hubcap nie powiodło się ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Gry</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Ostatnie</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nowe</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Brak ostatnio wydanych poprawek.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Nie udało się załadować ostatnich poprawek. Sprawdź połączenie.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pt-BR.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-BR.resx
@@ -527,4 +527,9 @@ Isso exclui os arquivos .lua de Steam\config\stplug-in. Reinicie o Steam depois 
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Você atingiu seu limite diário do Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Nenhum manifesto do Hubcap disponível para este app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Falha no download do Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Jogos</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recentes</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Novo</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Nenhuma correção lançada recentemente.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Não foi possível carregar as correções recentes. Verifique sua conexão.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pt-PT.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-PT.resx
@@ -527,4 +527,9 @@ Isto elimina os ficheiros .lua de Steam\config\stplug-in. Reinicie o Steam depoi
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Atingiste o teu limite diário do Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Nenhum manifesto Hubcap disponível para esta app.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Falha no download do Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Jogos</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recentes</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Novo</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Não há correções lançadas recentemente.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Não foi possível carregar as correções recentes. Verifique a sua ligação.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.resx
+++ b/src/LuaToolsGui/Resources/Strings.resx
@@ -352,6 +352,11 @@ This deletes the .lua files from Steam\config\stplug-in. Restart Steam afterward
   <data name="Fixes_Toast_CouldntApply" xml:space="preserve"><value>Couldn't apply fix</value></data>
   <data name="Fixes_Toast_Refreshed_Title" xml:space="preserve"><value>Refreshed</value></data>
   <data name="Fixes_Toast_Refreshed_Body" xml:space="preserve"><value>{0} games with fixes.</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Games</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recent</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>New</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>No fixes released recently.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Couldn't load recent fixes. Check your connection.</value></data>
 
   <!-- ── Add / Download page ── -->
   <data name="Add_Title" xml:space="preserve"><value>Let's get Luing™!</value></data>

--- a/src/LuaToolsGui/Resources/Strings.ro.resx
+++ b/src/LuaToolsGui/Resources/Strings.ro.resx
@@ -527,4 +527,9 @@ Aceasta șterge fișierele .lua din Steam\config\stplug-in. Repornește Steam du
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Ai atins limita zilnică Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Nu există manifest Hubcap pentru această aplicație.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Descărcarea Hubcap a eșuat ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Jocuri</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Recente</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Nou</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Nicio remediere lansată recent.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Nu s-au putut încărca remedierile recente. Verifică-ți conexiunea.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ru.resx
+++ b/src/LuaToolsGui/Resources/Strings.ru.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Достигнут дневной лимит Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Для этого приложения нет манифеста Hubcap.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Не удалось загрузить с Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Игры</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Последние</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Новое</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Свежих фиксов пока нет.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Не удалось загрузить свежие фиксы. Проверьте подключение.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.sv.resx
+++ b/src/LuaToolsGui/Resources/Strings.sv.resx
@@ -527,4 +527,9 @@ Detta tar bort .lua-filerna från Steam\config\stplug-in. Starta om Steam efter�
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Du har nått din dagliga Hubcap-gräns.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Det finns inget Hubcap-manifest för den här appen.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap-nedladdningen misslyckades ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Spel</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Senaste</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Ny</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Inga senaste fixar.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Det gick inte att läsa in senaste fixar. Kontrollera din anslutning.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.th.resx
+++ b/src/LuaToolsGui/Resources/Strings.th.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>คุณใช้ Hubcap ครบตามขีดจำกัดรายวันแล้ว</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>ไม่มี manifest ของ Hubcap สำหรับแอปนี้</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>ดาวน์โหลดจาก Hubcap ไม่สำเร็จ ({0})</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>เกม</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>ล่าสุด</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>ใหม่</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>ยังไม่มีการแก้ไขที่เผยแพร่ล่าสุด</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>ไม่สามารถโหลดการแก้ไขล่าสุดได้ โปรดตรวจสอบการเชื่อมต่อของคุณ</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.tr.resx
+++ b/src/LuaToolsGui/Resources/Strings.tr.resx
@@ -527,4 +527,9 @@ Bu işlem, .lua dosyalarını Steam\config\stplug-in konumundan siler. Değişik
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Günlük Hubcap sınırına ulaştın.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Bu uygulama için Hubcap manifesti yok.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap indirmesi başarısız ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Oyunlar</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Son</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Yeni</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Son zamanlarda yayımlanan düzeltme yok.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Son düzeltmeler yüklenemedi. Bağlantınızı kontrol edin.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.uk.resx
+++ b/src/LuaToolsGui/Resources/Strings.uk.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Досягнуто денний ліміт Hubcap.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Для цього застосунку немає маніфесту Hubcap.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Не вдалося завантажити з Hubcap ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Ігри</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Останні</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Нове</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Свіжих фіксів поки немає.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Не вдалося завантажити свіжі фікси. Перевірте з'єднання.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.vi.resx
+++ b/src/LuaToolsGui/Resources/Strings.vi.resx
@@ -527,4 +527,9 @@ Thao tác này sẽ xóa các tệp .lua khỏi Steam\config\stplug-in. Sau đó
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>Bạn đã đạt giới hạn Hubcap hằng ngày.</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>Không có manifest Hubcap cho ứng dụng này.</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Tải xuống từ Hubcap thất bại ({0}).</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>Trò chơi</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>Mới nhất</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>Mới</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>Chưa có bản sửa lỗi nào được phát hành gần đây.</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>Không thể tải bản sửa lỗi gần đây. Kiểm tra kết nối của bạn.</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
@@ -547,4 +547,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>已达到每日 Hubcap 限额。</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>此应用没有可用的 Hubcap 清单。</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap 下载失败（{0}）。</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>游戏</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>最近</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>新</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>暂无近期发布的修复。</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>无法加载最近的修复。请检查你的网络连接。</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
@@ -527,4 +527,9 @@
   <data name="Hubcap_Err_LimitReached" xml:space="preserve"><value>已達到每日 Hubcap 上限。</value></data>
   <data name="Hubcap_Err_NoManifest" xml:space="preserve"><value>此應用程式沒有可用的 Hubcap 資訊清單。</value></data>
   <data name="Hubcap_Err_DownloadFailed" xml:space="preserve"><value>Hubcap 下載失敗（{0}）。</value></data>
+  <data name="Fixes_Tab_Games" xml:space="preserve"><value>遊戲</value></data>
+  <data name="Fixes_Tab_Recent" xml:space="preserve"><value>最近</value></data>
+  <data name="Fixes_New" xml:space="preserve"><value>新</value></data>
+  <data name="Fixes_Recent_Empty" xml:space="preserve"><value>暫無近期發布的修正。</value></data>
+  <data name="Fixes_Recent_Err_Load" xml:space="preserve"><value>無法載入最近的修正。請檢查你的網路連線。</value></data>
 </root>

--- a/src/LuaToolsGui/Services/LuaToolsApiClient.cs
+++ b/src/LuaToolsGui/Services/LuaToolsApiClient.cs
@@ -189,6 +189,35 @@ public class LuaToolsApiClient(AuthService auth, SteamAppInfoCache appInfo, Cove
     }
 
     /// <summary>
+    /// Public: the most recently-published Denuvo fixes across ALL games. There's no /api/denuvo feed
+    /// endpoint, so this reads the (anon-readable) Supabase `denuvo_fixes` table directly via PostgREST,
+    /// the same way <see cref="GetStandardUsageAsync"/> reads `user_downloads`. Returns the newest
+    /// <paramref name="limit"/> fixes, each with its game name/header and tags embedded. Null on failure.
+    /// </summary>
+    public async Task<List<DenuvoRecentFix>?> GetRecentDenuvoFixesAsync(
+        int limit = 25, CancellationToken ct = default)
+    {
+        try
+        {
+            // PostgREST select with embedded resources (to-one denuvo_games; to-many denuvo_fix_tags,
+            // each carrying its denuvo_tags). Bounded read; anon RLS permits SELECT on these tables.
+            string url = $"{AppConfig.SupabaseUrl}/rest/v1/denuvo_fixes" +
+                         "?select=id,appid,title,description,created_at," +
+                         "denuvo_games(name,header_image)," +
+                         "denuvo_fix_tags(tag_id,denuvo_tags(id,name,slug,color))" +
+                         $"&order=created_at.desc&limit={limit}";
+
+            var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.TryAddWithoutValidation("apikey", AppConfig.SupabaseAnonKey);
+
+            using var res = await _http.SendAsync(req, ct);
+            if (!res.IsSuccessStatusCode) return null;
+            return await ReadJsonAsync<List<DenuvoRecentFix>>(res, ct);
+        }
+        catch { return null; } // offline / table locked down → the Recent tab shows its own error state
+    }
+
+    /// <summary>
     /// Auth: download a fix's "manifest" or "fix" slot. The endpoint returns a short-lived signed
     /// R2 URL (counts toward 25/day); we then fetch the file from that URL. Caller must be signed in.
     /// </summary>

--- a/src/LuaToolsGui/ViewModels/FixesViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/FixesViewModel.cs
@@ -8,6 +8,9 @@ using LuaToolsGui.Services;
 
 namespace LuaToolsGui.ViewModels;
 
+/// <summary>The two sub-tabs on the Fixes page: the game grid (default) and the recently-added feed.</summary>
+public enum FixesPage { Games, Recent }
+
 /// <summary>A game card in the Fixes grid.</summary>
 public partial class FixGameCardVm(DenuvoGameListing g) : ObservableObject
 {
@@ -65,6 +68,47 @@ public partial class FixItemVm(DenuvoFix f) : ObservableObject
         DateTimeOffset.TryParse(iso, out var d) ? d.UtcDateTime.ToString("d MMM yyyy") : "";
 }
 
+/// <summary>One entry in the Fixes page's "Recently added" feed (a fix, with its game + tags).</summary>
+public partial class RecentFixVm(DenuvoRecentFix f) : ObservableObject
+{
+    public string Id { get; } = f.Id;
+    public string AppId { get; } = f.AppId;
+    public string Title { get; } = f.Title;
+    public string? Description { get; } = f.Description;
+    public IReadOnlyList<DenuvoTag> Tags { get; } = f.Tags;
+
+    private readonly string? _headerImage = f.Game?.HeaderImage;
+    private readonly string? _createdAt = f.CreatedAt;
+
+    public string GameNameLabel =>
+        string.IsNullOrWhiteSpace(f.Game?.Name) ? $"App ID: {AppId}" : f.Game!.Name;
+    public string BuildLabel =>
+        string.Format(Resources.Strings.Fixes_Build, string.IsNullOrWhiteSpace(Title) ? "—" : Title);
+    public string DateLabel => FormatDate(_createdAt);
+    public bool IsNew => TryParseDate(_createdAt, out var d) && d >= DateTime.UtcNow.AddDays(-3);
+
+    /// <summary>Local cached cover path (set after CoverCache resolves it); bound via ImagePathToSource.</summary>
+    [ObservableProperty] private string? _cover;
+    private int _resolving;
+
+    public async Task EnsureCoverAsync(CoverCache covers)
+    {
+        if (Cover is not null || string.IsNullOrWhiteSpace(_headerImage)) return;
+        if (!long.TryParse(AppId, out long appid)) return;
+        if (Interlocked.Exchange(ref _resolving, 1) == 1) return;
+        try
+        {
+            string? local = covers.GetLocalPath(appid) ?? await covers.EnsureAsync(appid, _headerImage!);
+            if (local is not null) Cover = local;
+        }
+        finally { Interlocked.Exchange(ref _resolving, 0); }
+    }
+
+    private static bool TryParseDate(string? iso, out DateTimeOffset d) => DateTimeOffset.TryParse(iso, out d);
+    private static string FormatDate(string? iso) =>
+        DateTimeOffset.TryParse(iso, out var d) ? d.UtcDateTime.ToString("d MMM yyyy") : "";
+}
+
 /// <summary>
 /// "Fixes" page: browse games with Denuvo fixes (grid + search + tag filter), open a game to see its
 /// fixes, and download a fix's manifest (force-locked lua install) or fix zip (extract into the game
@@ -103,6 +147,32 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     private List<FixGameCardVm> _allGames = [];
 
     public ObservableCollection<TagPillVm> Tags { get; } = [];
+
+    // ── Sub-tabs: game grid (default) vs the recently-added fixes feed ──
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsGamesMode))]
+    [NotifyPropertyChangedFor(nameof(IsRecentMode))]
+    private FixesPage _page = FixesPage.Games;
+
+    public bool IsGamesMode => Page == FixesPage.Games;
+    public bool IsRecentMode => Page == FixesPage.Recent;
+
+    [RelayCommand]
+    private void ShowGames() => Page = FixesPage.Games;
+
+    [RelayCommand]
+    private void ShowRecent()
+    {
+        Page = FixesPage.Recent;
+        _ = LoadRecentAsync(); // usually a no-op: LoadAsync warms the feed at page load
+    }
+
+    public ObservableCollection<RecentFixVm> RecentFixes { get; } = [];
+    [ObservableProperty] private bool _isLoadingRecent;
+    [ObservableProperty] private string? _recentEmptyMessage;
+
+    /// <summary>True once the "Recent" feed has at least one entry (gates the feed vs its empty/error message).</summary>
+    public bool HasRecentItems => RecentFixes.Count > 0;
 
     // IsLoading, EmptyMessage and the IsEmpty gating are inherited from PagedListViewModel<FixGameCardVm>.
     // Page size persists via SavePageSizeSetting below.
@@ -166,6 +236,9 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
             foreach (var t in data.Tags) Tags.Add(new TagPillVm(t));
             ApplyFilter();
             if (_allGames.Count == 0) EmptyMessage = Resources.Strings.Fixes_Empty_None;
+
+            // Warm the "Recent" sub-tab in the background (one bounded PostgREST read, no auth).
+            _ = LoadRecentAsync();
         }
         catch
         {
@@ -177,12 +250,48 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
         }
     }
 
+    /// <summary>Fetch the most recently-published fixes (feed for the "Recent" sub-tab). Loads once per
+    /// session unless <paramref name="force"/> (the Refresh button) re-fetches.</summary>
+    public async Task LoadRecentAsync(bool force = false)
+    {
+        if (!force && RecentFixes.Count > 0) return;
+        IsLoadingRecent = true;
+        try
+        {
+            var fixes = await api.GetRecentDenuvoFixesAsync(limit: 25);
+            if (fixes is null)
+            {
+                RecentEmptyMessage = Resources.Strings.Fixes_Recent_Err_Load;
+                return;
+            }
+
+            RecentFixes.Clear();
+            foreach (var f in fixes) RecentFixes.Add(new RecentFixVm(f));
+            foreach (var f in RecentFixes) _ = f.EnsureCoverAsync(covers);
+            RecentEmptyMessage = RecentFixes.Count == 0 ? Resources.Strings.Fixes_Recent_Empty : null;
+            OnPropertyChanged(nameof(HasRecentItems));
+        }
+        catch
+        {
+            RecentEmptyMessage = Resources.Strings.Fixes_Recent_Err_Load;
+        }
+        finally
+        {
+            IsLoadingRecent = false;
+        }
+    }
+
+    [RelayCommand]
+    private Task OpenRecentFix(RecentFixVm fix) =>
+        long.TryParse(fix.AppId, out long appId) ? OpenForAppIdAsync(appId) : Task.CompletedTask;
+
     [RelayCommand]
     private Task Refresh() => RefreshWithCooldownAsync(async () =>
     {
         if (SearchText.Length > 0) SearchText = ""; // reset filter → full list visible
         if (SelectedTagId is not null) SelectTag(SelectedTagId); // clear active tag (toggles off)
         await LoadAsync(force: true);
+        await LoadRecentAsync(force: true);
         toast.Show(Resources.Strings.Fixes_Toast_Refreshed_Title,
             string.Format(Resources.Strings.Fixes_Toast_Refreshed_Body, _allGames.Count));
     });

--- a/src/LuaToolsGui/Views/FixesView.xaml
+++ b/src/LuaToolsGui/Views/FixesView.xaml
@@ -26,6 +26,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -47,16 +48,82 @@
                 Icon="{ui:SymbolIcon ArrowSync24}" />
         </Grid>
 
+        <!-- Sub-tabs: game grid vs recently-added fixes feed -->
+        <Border
+            Grid.Row="1"
+            Margin="0,14,0,0"
+            Padding="3"
+            HorizontalAlignment="Left"
+            Background="#0DFFFFFF"
+            BorderBrush="#14FFFFFF"
+            BorderThickness="1"
+            CornerRadius="8">
+            <StackPanel Orientation="Horizontal">
+                <Button Command="{Binding ShowGamesCommand}" Cursor="Hand">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Tab" Padding="18,6" CornerRadius="6" Background="Transparent">
+                                <TextBlock
+                                    x:Name="TabText"
+                                    FontSize="12.5"
+                                    FontWeight="SemiBold"
+                                    Foreground="#9ca3af"
+                                    Text="{x:Static res:Strings.Fixes_Tab_Games}" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Tab" Property="Background" Value="#14a78bfa" />
+                                </Trigger>
+                                <!-- Active: filled accent (declared last so it wins over hover). -->
+                                <DataTrigger Binding="{Binding IsGamesMode}" Value="True">
+                                    <Setter TargetName="Tab" Property="Background" Value="#a78bfa" />
+                                    <Setter TargetName="TabText" Property="Foreground" Value="#ffffff" />
+                                </DataTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+                <Button Command="{Binding ShowRecentCommand}" Cursor="Hand">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Tab" Padding="18,6" CornerRadius="6" Background="Transparent">
+                                <TextBlock
+                                    x:Name="TabText"
+                                    FontSize="12.5"
+                                    FontWeight="SemiBold"
+                                    Foreground="#9ca3af"
+                                    Text="{x:Static res:Strings.Fixes_Tab_Recent}" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Tab" Property="Background" Value="#14a78bfa" />
+                                </Trigger>
+                                <DataTrigger Binding="{Binding IsRecentMode}" Value="True">
+                                    <Setter TargetName="Tab" Property="Background" Value="#a78bfa" />
+                                    <Setter TargetName="TabText" Property="Foreground" Value="#ffffff" />
+                                </DataTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+            </StackPanel>
+        </Border>
+
         <!-- Search -->
         <ui:TextBox
-            Grid.Row="1"
+            Grid.Row="2"
             Margin="0,14,0,0"
             Icon="{ui:SymbolIcon Search24}"
             PlaceholderText="{x:Static res:Strings.Common_SearchPlaceholder}"
-            Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+            Visibility="{Binding IsGamesMode, Converter={StaticResource BoolToVis}}" />
 
         <!-- Tag filter pills -->
-        <ItemsControl Grid.Row="2" Margin="0,12,0,0" ItemsSource="{Binding Tags}">
+        <ItemsControl
+            Grid.Row="3"
+            Margin="0,12,0,0"
+            ItemsSource="{Binding Tags}"
+            Visibility="{Binding IsGamesMode, Converter={StaticResource BoolToVis}}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel Orientation="Horizontal" />
@@ -103,9 +170,14 @@
             </ItemsControl.ItemTemplate>
         </ItemsControl>
 
+        <!-- Games sub-tab: loading / empty / grid. Collapsed entirely in Recent mode. -->
+        <Grid
+            Grid.Row="4"
+            Visibility="{Binding IsGamesMode, Converter={StaticResource BoolToVis}}">
+
         <!-- Loading -->
         <StackPanel
-            Grid.Row="3"
+            Grid.Row="0"
             Margin="0,40,0,0"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
@@ -117,7 +189,7 @@
 
         <!-- Empty -->
         <TextBlock
-            Grid.Row="3"
+            Grid.Row="0"
             Margin="0,40,0,0"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
@@ -128,7 +200,7 @@
         <!-- Game grid -->
         <vwp:VirtualizingItemsControl
             x:Name="GameScroller"
-            Grid.Row="3"
+            Grid.Row="0"
             Margin="0,14,0,0"
             ItemsSource="{Binding Items}"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -185,13 +257,129 @@
                 </DataTemplate>
             </vwp:VirtualizingItemsControl.ItemTemplate>
         </vwp:VirtualizingItemsControl>
+        </Grid>
+
+        <!-- Recent sub-tab: feed of recently-added fixes. Hidden in Games mode. -->
+        <Grid
+            Grid.Row="4"
+            Margin="0,14,0,0"
+            Visibility="{Binding IsRecentMode, Converter={StaticResource BoolToVis}}">
+
+            <!-- Loading -->
+            <StackPanel
+                Margin="0,24,0,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Orientation="Horizontal"
+                Visibility="{Binding IsLoadingRecent, Converter={StaticResource BoolToVis}}">
+                <ui:ProgressRing Width="20" Height="20" IsIndeterminate="True" />
+                <TextBlock Margin="10,0,0,0" VerticalAlignment="Center" Foreground="#9ca3af" Text="{x:Static res:Strings.Fixes_Loading}" />
+            </StackPanel>
+
+            <!-- Empty / error -->
+            <TextBlock
+                Grid.Row="0"
+                Margin="0,32,0,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Foreground="#9ca3af"
+                Text="{Binding RecentEmptyMessage}"
+                Visibility="{Binding RecentEmptyMessage, Converter={StaticResource NullToCollapsed}}" />
+
+            <!-- Feed -->
+            <ScrollViewer
+                Grid.Row="0"
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto"
+                Visibility="{Binding HasRecentItems, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding RecentFixes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button
+                                    Margin="0,0,0,10"
+                                    HorizontalContentAlignment="Stretch"
+                                    Command="{Binding DataContext.OpenRecentFixCommand, ElementName=Root}"
+                                    CommandParameter="{Binding}"
+                                    Cursor="Hand">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border
+                                                x:Name="card"
+                                                Padding="12,10"
+                                                Background="#0DFFFFFF"
+                                                BorderBrush="#14FFFFFF"
+                                                BorderThickness="1"
+                                                CornerRadius="10">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Border Width="44" Height="44" Background="#11FFFFFF" ClipToBounds="True" CornerRadius="8">
+                                                        <Image Source="{Binding Cover, Converter={StaticResource ImagePathToSource}}" Stretch="UniformToFill" />
+                                                    </Border>
+                                                    <StackPanel Grid.Column="1" Margin="12,0,0,0" VerticalAlignment="Center">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <TextBlock FontSize="13" FontWeight="SemiBold" Foreground="#e5e7eb" Text="{Binding GameNameLabel}" TextTrimming="CharacterEllipsis" />
+                                                            <Border
+                                                                Margin="8,0,0,0"
+                                                                Padding="5,1"
+                                                                VerticalAlignment="Center"
+                                                                Background="#22c55e"
+                                                                CornerRadius="4"
+                                                                Visibility="{Binding IsNew, Converter={StaticResource BoolToVis}}">
+                                                                <TextBlock
+                                                                    FontSize="9.5"
+                                                                    FontWeight="Bold"
+                                                                    Foreground="#0b0a0f"
+                                                                    Text="{x:Static res:Strings.Fixes_New}" />
+                                                            </Border>
+                                                        </StackPanel>
+                                                        <TextBlock Margin="0,3,0,0" FontSize="11.5" Foreground="#6b7280" Text="{Binding Description}" TextTrimming="CharacterEllipsis" />
+                                                    </StackPanel>
+                                                </Grid>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="card" Property="Background" Value="#14a78bfa" />
+                                                    <Setter TargetName="card" Property="BorderBrush" Value="#28a78bfa" />
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
 
         <!-- Pager bar: page numbers centered across the full width, with results-per-page overlaid at the
              right. Shown once game cards are present. (Mirrors ManageView's pager.) -->
         <Grid
-            Grid.Row="4"
-            Margin="0,12,0,2"
-            Visibility="{Binding ShowItems, Converter={StaticResource BoolToVis}}">
+            Grid.Row="5"
+            Margin="0,12,0,2">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsGamesMode}" Value="True" />
+                                <Condition Binding="{Binding ShowItems}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Visible" />
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
 
             <!-- Centered group: ‹ prev | page numbers (fixed-width zone) | › next. -->
             <Grid
@@ -301,7 +489,7 @@
         <!-- ── Detail flyout ─────────────────────────────────────────── -->
         <Grid
             Grid.Row="0"
-            Grid.RowSpan="5"
+            Grid.RowSpan="6"
             Margin="-8,-16,-16,-8"
             Background="#80000000"
             Visibility="{Binding IsDetailOpen, Converter={StaticResource BoolToVis}}">


### PR DESCRIPTION
## Summary

Adds a **Recent** sub-tab to the Fixes page, showing the most recently published Denuvo fixes across all games (a "what's new" feed), alongside the existing **Games** grid.

The feed reads the public `denuvo_fixes` table directly from PostgREST (anon key, same pattern as `GetStandardUsageAsync` reading `user_downloads`), embedding each fix's game name/header image and tags in a single bounded query (`order=created_at.desc&limit=25`). There's no `/api/denuvo` "recent" endpoint, so no backend change is needed.

## What's included

- `FixesView.xaml`: new Games | Recent tab bar; the recent feed panel (loading ring, empty/error state, card list with cover, game name, "New" badge for fixes published within the last 3 days, description); search + tag pills + pager are gated to Games mode only.
- `FixesViewModel.cs`: `FixesPage` enum, `ShowGames`/`ShowRecent`/`OpenRecentFix` commands, `RecentFixes` collection + `RecentFixVm`, `LoadRecentAsync` (warm-started on page load, reloaded on Refresh), loading/empty/error state.
- `LuaToolsApiClient.cs`: `GetRecentDenuvoFixesAsync(limit, ct)` — bounded anon PostgREST read with embedded joins; returns `null` on failure.
- `FixModels.cs`: `DenuvoRecentFix`, `DenuvoRecentGame`, `DenuvoRecentFixTag`.
- Localization: 5 new keys (`Fixes_Tab_Games`, `Fixes_Tab_Recent`, `Fixes_New`, `Fixes_Recent_Empty`, `Fixes_Recent_Err_Load`) added to `Strings.resx`/`Strings.Designer.cs` **and translated in all 29 language files**. Since every key is now translated, `PENDING_TRANSLATION` in `check-i18n.py` is left empty (unchanged from upstream).

## Verification

- `python scripts/check-i18n.py` → `i18n check OK: 29 language files, 465 keys each, XML valid, placeholders consistent.`
- `dotnet build LuaToolsGui.sln` → 0 warnings, 0 errors.
- `dotnet test` → 207/207 passing.
- Manually verified the Recent tab loads real data from `db.lua.tools` and opens a game's fix view on click.
