### PR TITLE
Add page: offer the game's fixes right after a Fetch

### DIFF
--- a/src/LuaToolsGui/App.xaml.cs
+++ b/src/LuaToolsGui/App.xaml.cs
@@ -28,6 +28,7 @@ public partial class App : Application
                 services.AddSingleton<SteamAppListCache>();
                 services.AddSingleton<SteamAppInfoCache>();
                 services.AddSingleton<CoverCache>();
+                services.AddSingleton<FixLookupService>();
                 services.AddSingleton<ToastService>();
                 services.AddSingleton<SteamDepotInfo>();
                 services.AddSingleton<LuaVault>();
@@ -345,6 +346,13 @@ public partial class App : Application
         var home = _host.Services.GetRequiredService<HomeViewModel>();
         home.NavigateToGame = openInManage;
         download.NavigateToGame = openInManage;
+
+        // Add page → the post-fetch "this game has a fix" banner opens it straight in the Fixes page.
+        download.OpenFixesForGame = appId => Dispatcher.Invoke(() =>
+        {
+            window.NavigateToFixes();
+            _ = _host.Services.GetRequiredService<FixesViewModel>().OpenForAppIdAsync(appId);
+        });
         builds.NavigateToManage = openInManage; // Builds "Manage" button: the reverse of "Manage Build"
 
         // Dragging a SteamDB / Steam store link onto either drop box installs that appid. Routed through

--- a/src/LuaToolsGui/Resources/Strings.Designer.cs
+++ b/src/LuaToolsGui/Resources/Strings.Designer.cs
@@ -344,6 +344,9 @@ public static class Strings
     public static string Add_FastFetch_Hint => Get(nameof(Add_FastFetch_Hint));
     public static string Add_FastFetch_NoSource => Get(nameof(Add_FastFetch_NoSource));
     public static string Add_FastFetch_Via => Get(nameof(Add_FastFetch_Via));
+    public static string Add_Fix_Available => Get(nameof(Add_Fix_Available));
+    public static string Add_Fix_Available_Tags => Get(nameof(Add_Fix_Available_Tags));
+    public static string Add_Fix_Open => Get(nameof(Add_Fix_Open));
 
     // ── Confirm overlay ──
     public static string Confirm_OpenSteamDb => Get(nameof(Confirm_OpenSteamDb));

--- a/src/LuaToolsGui/Resources/Strings.ar.resx
+++ b/src/LuaToolsGui/Resources/Strings.ar.resx
@@ -400,6 +400,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>التنزيل التلقائي من أول مصدر متاح</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>لم يتم العثور على مصادر متاحة لهذه اللعبة</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· عبر {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>تتوفر لهذه اللعبة {0} إصلاح.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>تتوفر لهذه اللعبة {0} إصلاح: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>عرض الإصلاحات</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>إضافة LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>إضافة LuaTools لمتجر Steam! — تستخدم الآن LuaLoader بدلًا من Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>الحالة</value></data>

--- a/src/LuaToolsGui/Resources/Strings.bg.resx
+++ b/src/LuaToolsGui/Resources/Strings.bg.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Автоматично изтегляне от първия наличен източник</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Няма намерени налични източници за тази игра</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· чрез {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Тази игра има налични корекции: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Тази игра има налични корекции: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Виж корекциите</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools плъгин</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Плъгинът LuaTools за Steam! — Вече използва LuaLoader вместо Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Състояние</value></data>

--- a/src/LuaToolsGui/Resources/Strings.cs.resx
+++ b/src/LuaToolsGui/Resources/Strings.cs.resx
@@ -374,6 +374,9 @@ Tím se smažou soubory .lua ze Steam\config\stplug-in. Poté restartujte Steam,
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatické stažení z prvního dostupného zdroje</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Pro tuto hru nebyly nalezeny žádné dostupné zdroje</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· přes {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Pro tuto hru jsou k dispozici opravy: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Pro tuto hru jsou k dispozici opravy: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Zobrazit opravy</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Plugin LuaTools pro Steam! — Nyní používá LuaLoader místo Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Stav</value></data>

--- a/src/LuaToolsGui/Resources/Strings.da.resx
+++ b/src/LuaToolsGui/Resources/Strings.da.resx
@@ -374,6 +374,9 @@ Dette sletter .lua-filerne fra Steam\config\stplug-in. Genstart Steam bagefter, 
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatisk download fra den første tilgængelige kilde</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Ingen tilgængelige kilder fundet til dette spil</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Dette spil har {0} rettelser tilgængelige.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Dette spil har {0} rettelser tilgængelige: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Se rettelser</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-plugin</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools Steam-pluginet! — Bruger nu LuaLoader i stedet for Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.de.resx
+++ b/src/LuaToolsGui/Resources/Strings.de.resx
@@ -374,6 +374,9 @@ Dadurch werden die .lua-Dateien aus Steam\config\stplug-in gelöscht. Starte Ste
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatisch von der ersten verfügbaren Quelle herunterladen</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Keine verfügbaren Quellen für dieses Spiel gefunden</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· über {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Für dieses Spiel gibt es {0} Fixes.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Für dieses Spiel gibt es {0} Fixes: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Fixes ansehen</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-Plugin</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Das LuaTools-Steam-Plugin! — Nutzt jetzt LuaLoader statt Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.el.resx
+++ b/src/LuaToolsGui/Resources/Strings.el.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Αυτόματη λήψη από την πρώτη διαθέσιμη πηγή</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Δεν βρέθηκαν διαθέσιμες πηγές για αυτό το παιχνίδι</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· μέσω {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Αυτό το παιχνίδι έχει διαθέσιμες διορθώσεις: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Αυτό το παιχνίδι έχει διαθέσιμες διορθώσεις: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Δες τις διορθώσεις</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Πρόσθετο LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Το πρόσθετο LuaTools για το Steam! — Χρησιμοποιεί πλέον LuaLoader αντί για Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Κατάσταση</value></data>

--- a/src/LuaToolsGui/Resources/Strings.es-419.resx
+++ b/src/LuaToolsGui/Resources/Strings.es-419.resx
@@ -374,6 +374,9 @@ Esto borra los archivos .lua de Steam\config\stplug-in. Reinicia Steam después 
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Descargar automáticamente desde la primera fuente disponible</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>No se encontraron fuentes disponibles para este juego</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· a través de {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Este juego tiene {0} parche(s) disponible(s).</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Este juego tiene {0} parche(s) disponible(s): {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Ver parches</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Complemento LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>¡El plugin de LuaTools para Steam! — Ahora usa LuaLoader en vez de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Estado</value></data>

--- a/src/LuaToolsGui/Resources/Strings.es.resx
+++ b/src/LuaToolsGui/Resources/Strings.es.resx
@@ -374,6 +374,9 @@ Esto borra los archivos .lua de Steam\config\stplug-in. Reinicia Steam después 
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Descargar automáticamente desde la primera fuente disponible</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>No se encontraron fuentes disponibles para este juego</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· a través de {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Este juego tiene {0} parche(s) disponible(s).</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Este juego tiene {0} parche(s) disponible(s): {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Ver parches</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Complemento LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>¡El plugin de LuaTools para Steam! — Ahora usa LuaLoader en lugar de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Estado</value></data>

--- a/src/LuaToolsGui/Resources/Strings.fi.resx
+++ b/src/LuaToolsGui/Resources/Strings.fi.resx
@@ -374,6 +374,9 @@ Tämä poistaa .lua-tiedostot sijainnista Steam\config\stplug-in. Käynnistä St
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automaattinen lataus ensimmäisestä saatavilla olevasta lähteestä</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Tälle pelille ei löytynyt saatavilla olevia lähteitä</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· kautta {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Tälle pelille on saatavilla {0} korjausta.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Tälle pelille on saatavilla {0} korjausta: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Näytä korjaukset</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-laajennus</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools-Steam-laajennus! — Käyttää nyt LuaLoaderia Shitteniumin sijaan</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Tila</value></data>

--- a/src/LuaToolsGui/Resources/Strings.fr.resx
+++ b/src/LuaToolsGui/Resources/Strings.fr.resx
@@ -374,6 +374,9 @@ Cela supprime les fichiers .lua de Steam\config\stplug-in. Redémarrez Steam ens
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Téléchargement automatique depuis la première source disponible</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Aucune source disponible pour ce jeu</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Ce jeu a {0} correctif(s) disponible(s).</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Ce jeu a {0} correctif(s) disponible(s) : {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Voir les correctifs</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Extension LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Le plugin LuaTools pour Steam ! — Utilise désormais LuaLoader au lieu de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>État</value></data>

--- a/src/LuaToolsGui/Resources/Strings.hu.resx
+++ b/src/LuaToolsGui/Resources/Strings.hu.resx
@@ -374,6 +374,9 @@ Ez törli a .lua fájlokat a Steam\config\stplug-in mappából. Ezután indítsd
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatikus letöltés az első elérhető forrásból</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nem található elérhető forrás ehhez a játékhoz</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· innen: {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Ehhez a játékhoz {0} javítás érhető el.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Ehhez a játékhoz {0} javítás érhető el: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Javítások megtekintése</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools bővítmény</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>A LuaTools Steam bővítmény! — Mostantól LuaLoader a Shittenium helyett</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Állapot</value></data>

--- a/src/LuaToolsGui/Resources/Strings.id.resx
+++ b/src/LuaToolsGui/Resources/Strings.id.resx
@@ -374,6 +374,9 @@ Ini menghapus file .lua dari Steam\config\stplug-in. Mulai ulang Steam setelahny
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Unduh otomatis dari sumber pertama yang tersedia</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Tidak ada sumber tersedia yang ditemukan untuk game ini</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· melalui {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Game ini punya {0} perbaikan.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Game ini punya {0} perbaikan: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Lihat perbaikan</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Plugin LuaTools untuk Steam! — Kini memakai LuaLoader alih-alih Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.it.resx
+++ b/src/LuaToolsGui/Resources/Strings.it.resx
@@ -374,6 +374,9 @@ Questo elimina i file .lua da Steam\config\stplug-in. Riavvia Steam in seguito a
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Scarica automaticamente dalla prima fonte disponibile</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nessuna fonte disponibile trovata per questo gioco</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· tramite {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Questo gioco ha {0} fix disponibili.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Questo gioco ha {0} fix disponibili: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Vedi i fix</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Il plugin LuaTools per Steam! — Ora usa LuaLoader invece di Merdennium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Stato</value></data>

--- a/src/LuaToolsGui/Resources/Strings.ja.resx
+++ b/src/LuaToolsGui/Resources/Strings.ja.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>最初の利用可能なソースから自動ダウンロード</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>このゲームで利用可能なソースが見つかりません</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· ソース：{0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>このゲームには {0} 件の修正があります。</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>このゲームには {0} 件の修正があります：{1}</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>修正を見る</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools プラグイン</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools の Steam プラグイン！ — Shittenium に代わり LuaLoader を使用</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>ステータス</value></data>

--- a/src/LuaToolsGui/Resources/Strings.ko.resx
+++ b/src/LuaToolsGui/Resources/Strings.ko.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>사용 가능한 첫 번째 소스에서 자동 다운로드</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>이 게임에 사용 가능한 소스를 찾을 수 없습니다</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· 출처: {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>이 게임에는 수정 {0}개가 있습니다.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>이 게임에는 수정 {0}개가 있습니다: {1}</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>수정 보기</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools 플러그인</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools Steam 플러그인! — 이제 Shittenium 대신 LuaLoader 사용</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>상태</value></data>

--- a/src/LuaToolsGui/Resources/Strings.nb.resx
+++ b/src/LuaToolsGui/Resources/Strings.nb.resx
@@ -374,6 +374,9 @@ Dette sletter .lua-filene fra Steam\config\stplug-in. Start Steam på nytt etter
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatisk nedlasting fra første tilgjengelige kilde</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Ingen tilgjengelige kilder funnet for dette spillet</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Dette spillet har {0} fikser tilgjengelig.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Dette spillet har {0} fikser tilgjengelig: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Se fikser</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-programtillegg</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools Steam-programtillegget! — Bruker nå LuaLoader i stedet for Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.nl.resx
+++ b/src/LuaToolsGui/Resources/Strings.nl.resx
@@ -374,6 +374,9 @@ Dit verwijdert de .lua-bestanden uit Steam\config\stplug-in. Herstart Steam daar
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatisch downloaden van de eerste beschikbare bron</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Geen beschikbare bronnen gevonden voor dit spel</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Voor dit spel zijn {0} fixes beschikbaar.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Voor dit spel zijn {0} fixes beschikbaar: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Fixes bekijken</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-plug-in</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>De LuaTools Steam-plugin! — Gebruikt nu LuaLoader in plaats van Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.pl.resx
+++ b/src/LuaToolsGui/Resources/Strings.pl.resx
@@ -374,6 +374,9 @@ Spowoduje to usunięcie plików .lua z Steam\config\stplug-in. Następnie urucho
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatyczne pobieranie z pierwszego dostępnego źródła</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nie znaleziono dostępnych źródeł dla tej gry</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· przez {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Ta gra ma dostępne poprawki: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Ta gra ma dostępne poprawki: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Zobacz poprawki</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Wtyczka LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Wtyczka LuaTools do Steam! — Teraz używa LuaLoader zamiast Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Stan</value></data>

--- a/src/LuaToolsGui/Resources/Strings.pt-BR.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-BR.resx
@@ -374,6 +374,9 @@ Isso exclui os arquivos .lua de Steam\config\stplug-in. Reinicie o Steam depois 
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Baixar automaticamente da primeira fonte disponível</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nenhuma fonte disponível encontrada para este jogo</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Este jogo tem {0} correção(ões) disponível(is).</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Este jogo tem {0} correção(ões) disponível(is): {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Ver correções</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>O plugin LuaTools para Steam! — Agora usando LuaLoader em vez de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.pt-PT.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-PT.resx
@@ -374,6 +374,9 @@ Isto elimina os ficheiros .lua de Steam\config\stplug-in. Reinicie o Steam depoi
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Transferir automaticamente da primeira fonte disponível</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nenhuma fonte disponível encontrada para este jogo</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Este jogo tem {0} correção(ões) disponível(is).</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Este jogo tem {0} correção(ões) disponível(is): {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Ver correções</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>O plugin LuaTools para Steam! — Agora a usar LuaLoader em vez de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Estado</value></data>

--- a/src/LuaToolsGui/Resources/Strings.resx
+++ b/src/LuaToolsGui/Resources/Strings.resx
@@ -396,6 +396,9 @@ This deletes the .lua files from Steam\config\stplug-in. Restart Steam afterward
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Auto-download from the first available source</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>No available sources found for this game</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>This game has {0} fix(es) available.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>This game has {0} fix(es) available: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>See fixes</value></data>
 
   <!-- ── Confirm overlay (overwrite diff) ── -->
   <data name="Confirm_OpenSteamDb" xml:space="preserve"><value>Open on SteamDB</value></data>

--- a/src/LuaToolsGui/Resources/Strings.ro.resx
+++ b/src/LuaToolsGui/Resources/Strings.ro.resx
@@ -374,6 +374,9 @@ Aceasta șterge fișierele .lua din Steam\config\stplug-in. Repornește Steam du
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Descărcare automată de la prima sursă disponibilă</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Nu s-au găsit surse disponibile pentru acest joc</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· prin {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Acest joc are {0} remedieri disponibile.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Acest joc are {0} remedieri disponibile: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Vezi remedierile</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Pluginul LuaTools pentru Steam! — Acum folosește LuaLoader în loc de Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Stare</value></data>

--- a/src/LuaToolsGui/Resources/Strings.ru.resx
+++ b/src/LuaToolsGui/Resources/Strings.ru.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Автоматическая загрузка из первого доступного источника</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Для этой игры не найдено доступных источников</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· через {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Для этой игры есть фиксы: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Для этой игры есть фиксы: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Открыть фиксы</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Плагин LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Плагин LuaTools для Steam! — Теперь использует LuaLoader вместо Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Статус</value></data>

--- a/src/LuaToolsGui/Resources/Strings.sv.resx
+++ b/src/LuaToolsGui/Resources/Strings.sv.resx
@@ -374,6 +374,9 @@ Detta tar bort .lua-filerna från Steam\config\stplug-in. Starta om Steam efter�
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Automatisk nedladdning från första tillgängliga källan</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Inga tillgängliga källor hittades för detta spel</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· via {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Det här spelet har {0} fixar tillgängliga.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Det här spelet har {0} fixar tillgängliga: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Visa fixar</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools-tillägg</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools Steam-tillägget! — Använder nu LuaLoader istället för Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Status</value></data>

--- a/src/LuaToolsGui/Resources/Strings.th.resx
+++ b/src/LuaToolsGui/Resources/Strings.th.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>ดาวน์โหลดอัตโนมัติจากแหล่งแรกที่พร้อมใช้งาน</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>ไม่พบแหล่งที่พร้อมใช้งานสำหรับเกมนี้</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· ผ่าน {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>เกมนี้มีการแก้ไข {0} รายการ</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>เกมนี้มีการแก้ไข {0} รายการ: {1}</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>ดูการแก้ไข</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>ปลั๊กอิน LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>ปลั๊กอิน LuaTools สำหรับ Steam! — ตอนนี้ใช้ LuaLoader แทน Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>สถานะ</value></data>

--- a/src/LuaToolsGui/Resources/Strings.tr.resx
+++ b/src/LuaToolsGui/Resources/Strings.tr.resx
@@ -374,6 +374,9 @@ Bu işlem, .lua dosyalarını Steam\config\stplug-in konumundan siler. Değişik
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>İlk kullanılabilir kaynaktan otomatik indir</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Bu oyun için kullanılabilir kaynak bulunamadı</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· {0} aracılığıyla</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Bu oyun için {0} düzeltme mevcut.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Bu oyun için {0} düzeltme mevcut: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Düzeltmeleri gör</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools Eklentisi</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools Steam eklentisi! — Artık Shittenium yerine LuaLoader kullanıyor</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Durum</value></data>

--- a/src/LuaToolsGui/Resources/Strings.uk.resx
+++ b/src/LuaToolsGui/Resources/Strings.uk.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Автоматичне завантаження з першого доступного джерела</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Для цієї гри не знайдено доступних джерел</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· через {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Для цієї гри є фікси: {0}.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Для цієї гри є фікси: {0} ({1}).</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Відкрити фікси</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Плагін LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Плагін LuaTools для Steam! — Тепер використовує LuaLoader замість Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Статус</value></data>

--- a/src/LuaToolsGui/Resources/Strings.vi.resx
+++ b/src/LuaToolsGui/Resources/Strings.vi.resx
@@ -374,6 +374,9 @@ Thao tác này sẽ xóa các tệp .lua khỏi Steam\config\stplug-in. Sau đó
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>Tự động tải xuống từ nguồn có sẵn đầu tiên</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>Không tìm thấy nguồn khả dụng cho trò chơi này</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· qua {0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>Trò chơi này có {0} bản sửa lỗi.</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>Trò chơi này có {0} bản sửa lỗi: {1}.</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>Xem bản sửa lỗi</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>Plugin LuaTools</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>Plugin LuaTools cho Steam! — Giờ đây dùng LuaLoader thay cho Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>Trạng thái</value></data>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
@@ -394,6 +394,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>自动从首个可用源下载</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>未找到此游戏的可用源</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· 来源：{0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>这款游戏有 {0} 个修复可用。</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>这款游戏有 {0} 个修复可用：{1}</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>查看修复</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools 插件</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools 的 Steam 插件！ — 现已改用 LuaLoader 代替 Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>状态</value></data>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
@@ -374,6 +374,9 @@
   <data name="Add_FastFetch_Hint" xml:space="preserve"><value>自動從首個可用來源下載</value></data>
   <data name="Add_FastFetch_NoSource" xml:space="preserve"><value>未找到此遊戲的可用來源</value></data>
   <data name="Add_FastFetch_Via" xml:space="preserve"><value>· 來源：{0}</value></data>
+  <data name="Add_Fix_Available" xml:space="preserve"><value>這款遊戲有 {0} 個修正可用。</value></data>
+  <data name="Add_Fix_Available_Tags" xml:space="preserve"><value>這款遊戲有 {0} 個修正可用：{1}</value></data>
+  <data name="Add_Fix_Open" xml:space="preserve"><value>查看修正</value></data>
   <data name="Plugin_Title" xml:space="preserve"><value>LuaTools 外掛</value></data>
   <data name="Plugin_Subtitle" xml:space="preserve"><value>LuaTools 的 Steam 外掛！ — 現已改用 LuaLoader 取代 Shittenium</value></data>
   <data name="Plugin_CardTitle" xml:space="preserve"><value>狀態</value></data>

--- a/src/LuaToolsGui/Services/FixLookupService.cs
+++ b/src/LuaToolsGui/Services/FixLookupService.cs
@@ -1,0 +1,69 @@
+namespace LuaToolsGui.Services;
+
+/// <summary>What the fix listing knows about one game: how many fixes, and what kind they are.</summary>
+/// <param name="Tags">
+/// The fixes' categories as the listing names them ("Online Fix", "Ubisoft", …). Worth showing,
+/// because the endpoint is called "denuvo" but the listing is overwhelmingly not: of the games it
+/// returns, the vast majority are Online Fixes and no tag named "Denuvo" exists at all.
+/// </param>
+public record GameFixSummary(int Count, IReadOnlyList<string> Tags);
+
+/// <summary>
+/// Answers one question for the Add page: does this game have fixes, how many, and of what kind?
+///
+/// <para>
+/// The listing endpoint returns every game that has a fix in one shot, so it is fetched once per
+/// session and kept as an appid → summary map. That keeps "did the game I just fetched have a fix?"
+/// free after the first lookup, instead of a per-game request while the user types.
+/// </para>
+///
+/// <para>
+/// Best-effort by design: no listing (offline, API down) means no banner, never an error. A failed
+/// load isn't cached, so the next lookup tries again.
+/// </para>
+/// </summary>
+public class FixLookupService(LuaToolsApiClient api)
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private IReadOnlyDictionary<long, GameFixSummary>? _summaries;
+
+    /// <summary>What the listing has for this appid, or null when it has nothing for it — which also
+    /// covers "the listing couldn't be loaded" (the caller can't tell, and doesn't need to).</summary>
+    public async Task<GameFixSummary?> GetFixSummaryAsync(long appId, CancellationToken ct = default)
+    {
+        var summaries = await EnsureLoadedAsync(ct);
+        return summaries is not null && summaries.TryGetValue(appId, out var summary) ? summary : null;
+    }
+
+    private async Task<IReadOnlyDictionary<long, GameFixSummary>?> EnsureLoadedAsync(CancellationToken ct)
+    {
+        if (_summaries is not null) return _summaries;
+
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_summaries is not null) return _summaries; // won the race elsewhere
+
+            var listing = await api.GetDenuvoListingsAsync(ct);
+            if (listing is null) return null; // don't cache a failure. Retry on the next lookup
+
+            var summaries = new Dictionary<long, GameFixSummary>();
+            foreach (var game in listing.Games)
+                if (long.TryParse(game.AppId, out long id) && game.FixCount > 0)
+                    summaries[id] = new GameFixSummary(
+                        game.FixCount,
+                        game.Tags.Select(t => t.Name).Where(n => !string.IsNullOrWhiteSpace(n)).ToList());
+
+            return _summaries = summaries;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            return null; // same as above: silence, and try again next time
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/LuaToolsGui/ViewModels/DownloadViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/DownloadViewModel.cs
@@ -81,6 +81,7 @@ public partial class DownloadViewModel : ObservableObject
     private readonly SteamAppInfoCache _appInfo;
     private readonly SteamDepotInfo _depotInfo;
     private readonly HardwareAppIdService _hardware;
+    private readonly FixLookupService _fixes;
     private CancellationTokenSource? _searchCts;
     private CancellationTokenSource? _detailsCts;
 
@@ -92,6 +93,9 @@ public partial class DownloadViewModel : ObservableObject
 
     /// <summary>Set by App: navigate to Manage and open this appid's detail (the install banner's "Reveal").</summary>
     public Action<long>? NavigateToGame { get; set; }
+
+    /// <summary>Set by App: navigate to Fixes and open this appid's fixes (the post-fetch banner).</summary>
+    public Action<long>? OpenFixesForGame { get; set; }
 
     public ObservableCollection<SteamSearchResult> SearchResults { get; } = [];
     public ObservableCollection<SourceRowViewModel> Sources { get; } = [];
@@ -123,6 +127,31 @@ public partial class DownloadViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(ShowFeatured))]
     [NotifyCanExecuteChangedFor(nameof(FetchCommand))]
     private GameDetails? _details;
+
+    /// <summary>
+    /// Number of published fixes for the fetched game, filled in by <see cref="CheckFixesAsync"/> after
+    /// a Fetch. 0 hides the banner, which is also what a failed lookup leaves behind.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasFix))]
+    [NotifyPropertyChangedFor(nameof(FixBannerText))]
+    private int _fixCount;
+
+    /// <summary>What kind of fixes they are ("Online Fix", "Ubisoft", …), straight from the listing.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FixBannerText))]
+    private string _fixTags = "";
+
+    public bool HasFix => FixCount > 0;
+
+    /// <summary>
+    /// The banner sentence. The kinds are named when the listing gives them, because "a fix" says very
+    /// little: the same listing covers Online Fixes, Ubisoft and Rockstar fixes, achievement fixes and
+    /// more, and telling the user which one is waiting is the whole point of the banner.
+    /// </summary>
+    public string FixBannerText => FixTags.Length > 0
+        ? string.Format(Resources.Strings.Add_Fix_Available_Tags, FixCount, FixTags)
+        : string.Format(Resources.Strings.Add_Fix_Available, FixCount);
 
     public bool HasDetails => Details is not null;
     public string GenresText => Details is null ? "" : string.Join(", ", Details.Genres);
@@ -295,7 +324,7 @@ public partial class DownloadViewModel : ObservableObject
     public DownloadViewModel(LuaToolsApiClient api, HubcapService hubcap, SettingsService settings,
         AuthService auth, ToastService toast, LuaInstaller installer,
         SteamAppListCache appList, SteamAppInfoCache appInfo, SteamDepotInfo depotInfo,
-        HardwareAppIdService hardware, DropInstallViewModel drop)
+        HardwareAppIdService hardware, FixLookupService fixes, DropInstallViewModel drop)
     {
         _api = api;
         _hubcap = hubcap;
@@ -307,6 +336,7 @@ public partial class DownloadViewModel : ObservableObject
         _appInfo = appInfo;
         _depotInfo = depotInfo;
         _hardware = hardware;
+        _fixes = fixes;
         Drop = drop;
         _fastFetch = settings.FastFetch;
     }
@@ -502,6 +532,11 @@ public partial class DownloadViewModel : ObservableObject
             }
             else
             {
+                // Independent of the source check, and deliberately not awaited: whether the game has a
+                // Denuvo fix has no bearing on fetching its manifest sources, and the banner showing a
+                // moment later is better than holding up the fetch.
+                _ = CheckFixesAsync(Details.AppId);
+
                 var statuses = await _api.CheckSourcesAsync(Details.AppId.ToString());
 
                 // The manifest backend no longer reports the Hubcap/Morrenus source. Synthesize it
@@ -544,6 +579,38 @@ public partial class DownloadViewModel : ObservableObject
         {
             IsChecking = false;
         }
+    }
+
+    /// <summary>
+    /// Look up how many Denuvo fixes exist for the game that was just fetched, and surface the banner.
+    ///
+    /// <para>
+    /// The result is dropped if the user has moved on to another game in the meantime: the lookup can
+    /// outlive the fetch that started it, and a banner advertising fixes for the previous game would be
+    /// worse than no banner at all.
+    /// </para>
+    /// </summary>
+    private async Task CheckFixesAsync(long appId)
+    {
+        try
+        {
+            var summary = await _fixes.GetFixSummaryAsync(appId);
+            if (Details?.AppId != appId) return; // user moved on. Drop it
+
+            FixCount = summary?.Count ?? 0;
+            FixTags = summary is null ? "" : string.Join(", ", summary.Tags);
+        }
+        catch
+        {
+            // Offline / API down. The banner just doesn't appear.
+        }
+    }
+
+    /// <summary>Banner action: jump to the Fixes page with this game already open.</summary>
+    [RelayCommand]
+    private void OpenFixes()
+    {
+        if (Details is { } details) OpenFixesForGame?.Invoke(details.AppId);
     }
 
     /// <summary>The Hubcap source name as the website/source-meta keys it.</summary>
@@ -945,6 +1012,8 @@ public partial class DownloadViewModel : ObservableObject
         Error = null;
         LastDownload = null;
         _fastFetchSource = null;
+        FixCount = 0;
+        FixTags = "";
     }
 
     /// <summary>

--- a/src/LuaToolsGui/Views/DownloadView.xaml
+++ b/src/LuaToolsGui/Views/DownloadView.xaml
@@ -365,6 +365,42 @@
                 TextWrapping="Wrap"
                 Visibility="{Binding Error, Converter={StaticResource NullToCollapsed}}" />
 
+            <!-- Denuvo fix banner: shown after a Fetch when the game has published fixes. Purple, so it
+                 reads as an offer rather than a result (green) or a problem (amber). -->
+            <Border
+                Margin="0,12,0,0"
+                Padding="12,9"
+                Background="#14a78bfa"
+                BorderBrush="#40a78bfa"
+                BorderThickness="1"
+                CornerRadius="8"
+                Visibility="{Binding HasFix, Converter={StaticResource BoolToVis}}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:SymbolIcon
+                        VerticalAlignment="Center"
+                        Foreground="#a78bfa"
+                        Symbol="ShieldTask24" />
+                    <TextBlock
+                        Grid.Column="1"
+                        Margin="10,0"
+                        VerticalAlignment="Center"
+                        FontSize="13"
+                        Text="{Binding FixBannerText}"
+                        TextWrapping="Wrap" />
+                    <ui:Button
+                        Grid.Column="2"
+                        Appearance="Primary"
+                        Command="{Binding OpenFixesCommand}"
+                        Content="{x:Static res:Strings.Add_Fix_Open}"
+                        Icon="{ui:SymbolIcon ShieldTask24}" />
+                </Grid>
+            </Border>
+
             <!-- Install result banner (green on success, amber on partial/failed) -->
             <Border
                 Margin="0,12,0,0"


### PR DESCRIPTION
After a **Fetch** on the Add page, when the game has published fixes, a banner names them and takes you there:

> This game has 2 fix(es) available: SteamTools Achievements Fix, voices38 (crack). **[ See fixes ]**

The button opens the Fixes page with that game already unfolded — the same route `luatools://fix/` takes.

**Why it names the kind.** The endpoint is `/api/denuvo/listings`, but of the 1759 games it returns, **1621 are tagged "Online Fix"** and no tag named "Denuvo" exists at all. Calling them Denuvo fixes would be wrong nearly every time, so the banner uses the tags the Fixes page already shows as pills. No tags on a game's fixes → plain sentence, no kinds.

Three behaviours worth knowing:

- The lookup runs **alongside** the source check, never before it: whether a fix exists has no bearing on fetching manifests, so a Fetch is never held up by it.
- A result that lands after the user moved on is dropped, so the banner can't advertise the previous game's fixes.
- Games only — a DLC's fetch is about its depots, and a fix belongs to the base game. API unreachable means no banner, never an error.

`FixLookupService` fetches the listing once per session and keeps an appid → summary map, so the check is free after the first lookup.

Both strings are translated in all 29 languages; `scripts/check-i18n.py` passes. `dotnet build -c Release`: 0 warnings, 0 errors.

Independent of [#39](https://github.com/madoiscool/LuaTools/pull/39) — different files, no shared code, mergeable in either order.