### PR TITLE
Let manifest sources be declared in JSON

### DIFF
--- a/SOURCES.md
+++ b/SOURCES.md
@@ -1,0 +1,56 @@
+# Manifest sources as JSON
+
+Extra manifest sources can be declared in `.json` files under
+`%AppData%\LuaToolsGui\sources\`. A source declared this way appears as a row on the **Add** page and
+installs through the same pipeline as any other.
+
+Settings → *Manifest sources* lists the files found, what each contributed, and why anything was
+refused. Files are re-read whenever that page is opened, so there is nothing to restart.
+
+## Why
+
+The sources the app can fetch from are otherwise fixed at build time. Following a repo that moved, or
+adding a community one, means cutting a release. This makes it a line of JSON.
+
+## Data only
+
+A file can say **where** manifests are fetched from. It cannot supply code, a binary, or a fetch routine
+of its own: it names one of the shapes the app already knows how to consume, and the app does the
+fetching. Installing one of these files cannot execute anything.
+
+## Format
+
+`%AppData%\LuaToolsGui\sources\example.json`:
+
+```json
+{
+  "schema": 1,
+  "name": "Example sources",
+  "author": "you",
+  "sources": [
+    {
+      "name": "example-zip",
+      "displayName": "Example",
+      "kind": "manifestZip",
+      "url": "https://raw.githubusercontent.com/someone/some-repo/main/{appid}.zip",
+      "mirrors": ["https://cdn.jsdelivr.net/gh/someone/some-repo@main/{appid}.zip"],
+      "badge": "Free"
+    }
+  ]
+}
+```
+
+| Field | |
+|---|---|
+| `kind` | `manifestZip` — one `<appid>.zip` holding the lua and its `.manifest` files.<br>`luaFile` — one `<appid>.lua`, entitlements and depot keys only. |
+| `url` | Must be `https` and contain `{appid}`. |
+| `mirrors` | Tried in order when the primary is unreachable. Optional. |
+| `displayName` | Row label. Defaults to `name`. |
+| `badge` | Short label on the row. Cosmetic. Optional. |
+
+A source is refused, with the reason shown in Settings, if it uses a name the app already uses, is not
+`https`, has no `{appid}`, or names a `kind` that does not exist. One bad entry never takes the file's
+good ones down with it.
+
+GitHub urls go through the app's existing mirror fallback, the availability check included. A host that
+refuses `HEAD` is probed with a one-byte ranged `GET` instead.

--- a/src/LuaToolsGui/App.xaml.cs
+++ b/src/LuaToolsGui/App.xaml.cs
@@ -30,6 +30,8 @@ public partial class App : Application
                 services.AddSingleton<CoverCache>();
                 services.AddSingleton<ToastService>();
                 services.AddSingleton<SteamDepotInfo>();
+                services.AddSingleton<Services.Sources.SourcePackRegistry>();
+                services.AddSingleton<Services.Sources.PackSourceService>();
                 services.AddSingleton<LuaVault>();
                 services.AddSingleton<Services.AppInfo.LaunchModStore>();
                 services.AddSingleton<Services.AppInfo.LaunchOptionsService>();

--- a/src/LuaToolsGui/Resources/Strings.Designer.cs
+++ b/src/LuaToolsGui/Resources/Strings.Designer.cs
@@ -599,4 +599,10 @@ public static class Strings
     public static string Depot_Err_NoKeyFor => Get(nameof(Depot_Err_NoKeyFor));
     public static string Builds_Select_SharedHint => Get(nameof(Builds_Select_SharedHint));
     public static string Downloads_ClearHistory_Confirm => Get(nameof(Downloads_ClearHistory_Confirm));
+    public static string Sources_Err_Fetch => Get(nameof(Sources_Err_Fetch));
+    public static string Settings_Section_Sources => Get(nameof(Settings_Section_Sources));
+    public static string Settings_SourcePacks_Hint => Get(nameof(Settings_SourcePacks_Hint));
+    public static string Settings_SourcePacks_Open => Get(nameof(Settings_SourcePacks_Open));
+    public static string Settings_SourcePacks_None => Get(nameof(Settings_SourcePacks_None));
+    public static string Settings_SourcePacks_Count => Get(nameof(Settings_SourcePacks_Count));
 }

--- a/src/LuaToolsGui/Resources/Strings.ar.resx
+++ b/src/LuaToolsGui/Resources/Strings.ar.resx
@@ -645,4 +645,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>تغيّر {0} منذ تطبيق هذا الإصلاح، لذا فإن استعادته ستستبدل تلك التغييرات. إذا طبّقت إصلاحًا آخر فوقه، فتراجع عنه أولاً. الملفات المتأثرة: {1}.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>تم التراجع عن الإصلاح جزئيًا</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>تعذّرت استعادة {0} من الملفات. أغلق اللعبة وحاول مرة أخرى.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>هذا المصدر لا يحتوي على هذه اللعبة، أو تعذّر الوصول إليه.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>مصادر المانيفست</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>مصادر إضافية معرَّفة في ملفات ‎.json. بيانات فقط: الملف يحدّد من أين تُجلب المانيفستات، ولا يُنفَّذ منه أي شيء.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>فتح المجلد</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>لا توجد ملفات مصادر بعد.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>المصادر: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.bg.resx
+++ b/src/LuaToolsGui/Resources/Strings.bg.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} е променен, откакто беше приложена тази поправка, така че възстановяването ще презапише тези промени. Ако сте приложили друга поправка отгоре, първо върнете нея. Засегнати са {1} файла.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Корекцията е върната частично</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} файл(а) не можаха да бъдат възстановени. Затворете играта и опитайте отново.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Този източник няма тази игра или е недостъпен.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Източници на манифести</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Допълнителни източници, описани във файлове .json. Само данни: файлът казва откъде да се вземат манифести и нищо в него не се изпълнява.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Отваряне на папката</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Все още няма файлове с източници.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>източници: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.cs.resx
+++ b/src/LuaToolsGui/Resources/Strings.cs.resx
@@ -619,4 +619,10 @@ Zrušit - pokračovat ve stahování</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Soubor {0} se od použití této opravy změnil, takže obnovení by tyto změny přepsalo. Pokud jste navrch použili jinou opravu, vraťte nejprve ji. Dotčeno {1} souborů.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Oprava vrácena zpět částečně</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} soubor(ů) se nepodařilo obnovit. Zavřete hru a zkuste to znovu.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Tento zdroj tuto hru nemá, nebo je nedostupný.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Zdroje manifestů</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Další zdroje deklarované v souborech .json. Pouze data: soubor říká, odkud manifesty stáhnout, a nic z něj se nespouští.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Otevřít složku</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Zatím žádné soubory zdrojů.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>zdroje: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.da.resx
+++ b/src/LuaToolsGui/Resources/Strings.da.resx
@@ -619,4 +619,10 @@ Annuller - fortsæt download</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} er ændret, siden denne rettelse blev anvendt, så en gendannelse ville overskrive de ændringer. Hvis du har anvendt en anden rettelse ovenpå, så fortryd den først. {1} fil(er) berørt.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Rettelse delvist fortrudt</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} fil(er) kunne ikke gendannes. Luk spillet og prøv igen.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Denne kilde har ikke dette spil, eller kunne ikke nås.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifestkilder</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Ekstra kilder angivet i .json-filer. Kun data: en fil siger, hvor manifester hentes fra, og intet i den køres.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Åbn mappen</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Ingen kildefiler endnu.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>kilder: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.de.resx
+++ b/src/LuaToolsGui/Resources/Strings.de.resx
@@ -619,4 +619,10 @@ Abbrechen - weiter herunterladen</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} wurde seit dem Anwenden dieses Fixes geändert; eine Wiederherstellung würde diese Änderungen überschreiben. Falls du einen weiteren Fix darüber angewendet hast, setze zuerst diesen zurück. {1} Datei(en) betroffen.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Fix teilweise rückgängig gemacht</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} Datei(en) konnten nicht wiederhergestellt werden. Schließe das Spiel und versuche es erneut.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Diese Quelle hat dieses Spiel nicht oder war nicht erreichbar.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifest-Quellen</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Zusätzliche Quellen, in .json-Dateien deklariert. Nur Daten: eine Datei sagt, woher Manifeste geholt werden, ausgeführt wird daraus nie etwas.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Ordner öffnen</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Noch keine Quellendateien.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>Quellen: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.el.resx
+++ b/src/LuaToolsGui/Resources/Strings.el.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Το {0} έχει αλλάξει από τότε που εφαρμόστηκε αυτή η διόρθωση, οπότε η επαναφορά θα αντικαταστήσει αυτές τις αλλαγές. Αν εφαρμόσατε άλλη διόρθωση από πάνω, επαναφέρετε πρώτα εκείνη. Επηρεάζονται {1} αρχεία.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Η διόρθωση αναιρέθηκε μερικώς</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Δεν ήταν δυνατή η επαναφορά {0} αρχείων. Κλείστε το παιχνίδι και δοκιμάστε ξανά.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Αυτή η πηγή δεν έχει αυτό το παιχνίδι, ή δεν ήταν προσβάσιμη.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Πηγές manifest</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Επιπλέον πηγές δηλωμένες σε αρχεία .json. Μόνο δεδομένα: το αρχείο λέει από πού λαμβάνονται τα manifest, και τίποτα μέσα του δεν εκτελείται.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Άνοιγμα φακέλου</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Δεν υπάρχουν ακόμη αρχεία πηγών.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>πηγές: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.es-419.resx
+++ b/src/LuaToolsGui/Resources/Strings.es-419.resx
@@ -619,4 +619,10 @@ Cancelar: seguir descargando</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} cambió desde que se aplicó este fix, así que restaurarlo sobrescribiría esos cambios. Si aplicaste otro fix encima, revierte ese primero. {1} archivo(s) afectado(s).</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Parche revertido parcialmente</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>No se pudieron restaurar {0} archivo(s). Cerrá el juego y probá de nuevo.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Esta fuente no tiene este juego, o no se pudo contactar.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Fuentes de manifiestos</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Fuentes adicionales declaradas en archivos .json. Solo datos: un archivo indica de dónde obtener manifiestos, y nada en él se ejecuta.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Abrir la carpeta</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Aún no hay archivos de fuentes.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>fuentes: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.es.resx
+++ b/src/LuaToolsGui/Resources/Strings.es.resx
@@ -619,4 +619,10 @@ Cancelar: seguir descargando</value></data>
   <data name="Depot_Err_NoKeyFor" xml:space="preserve"><value>No hay clave de descifrado en el Lua para el depot {0}.</value></data>
   <data name="Builds_Select_SharedHint" xml:space="preserve"><value>Runtime compartido: normalmente ya está instalado. Marca para descargarlo igualmente.</value></data>
   <data name="Downloads_ClearHistory_Confirm" xml:space="preserve"><value>¿Quitar las {0} entradas del historial de descargas? Los archivos descargados no se ven afectados.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Esta fuente no tiene este juego, o no se pudo contactar.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Fuentes de manifiestos</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Fuentes adicionales declaradas en archivos .json. Solo datos: un archivo indica de dónde obtener manifiestos, y nada en él se ejecuta.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Abrir la carpeta</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Aún no hay archivos de fuentes.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>fuentes: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.fi.resx
+++ b/src/LuaToolsGui/Resources/Strings.fi.resx
@@ -619,4 +619,10 @@ Peruuta - jatka lataamista</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} on muuttunut tämän korjauksen käyttöönoton jälkeen, joten palauttaminen korvaisi nuo muutokset. Jos otit päälle toisen korjauksen, peru ensin se. {1} tiedosto(a) koskee.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Korjaus peruttu osittain</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} tiedostoa ei voitu palauttaa. Sulje peli ja yritä uudelleen.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Tässä lähteessä ei ole tätä peliä, tai siihen ei saatu yhteyttä.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifestilähteet</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Lisälähteitä .json-tiedostoissa. Pelkkää dataa: tiedosto kertoo mistä manifestit haetaan, eikä siitä suoriteta mitään.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Avaa kansio</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Ei vielä lähdetiedostoja.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>lähteet: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.fr.resx
+++ b/src/LuaToolsGui/Resources/Strings.fr.resx
@@ -619,4 +619,10 @@ Annuler - continuer le téléchargement</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} a changé depuis l'application de ce correctif ; le restaurer écraserait ces modifications. Si vous avez appliqué un autre correctif par-dessus, annulez-le d'abord. {1} fichier(s) concerné(s).</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Correctif partiellement annulé</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Impossible de restaurer {0} fichier(s). Fermez le jeu et réessayez.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Cette source n'a pas ce jeu, ou n'a pas pu être jointe.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Sources de manifests</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Sources supplémentaires déclarées dans des fichiers .json. Uniquement des données : un fichier indique où récupérer des manifests, rien n'y est jamais exécuté.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Ouvrir le dossier</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Aucun fichier de source pour l'instant.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>sources : {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.hu.resx
+++ b/src/LuaToolsGui/Resources/Strings.hu.resx
@@ -619,4 +619,10 @@ Mégse - letöltés folytatása</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>A(z) {0} megváltozott a javítás alkalmazása óta, ezért a visszaállítás felülírná ezeket a módosításokat. Ha másik javítást is alkalmaztál rá, előbb azt vond vissza. {1} fájl érintett.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>A javítás részben lett visszavonva</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} fájlt nem sikerült visszaállítani. Zárd be a játékot, és próbáld újra.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Ez a forrás nem tartalmazza ezt a játékot, vagy nem érhető el.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifest-források</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>További források .json fájlokban megadva. Csak adat: a fájl megmondja, honnan töltsük le a manifesteket, és semmi nem fut le belőle.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Mappa megnyitása</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Még nincs forrásfájl.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>források: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.id.resx
+++ b/src/LuaToolsGui/Resources/Strings.id.resx
@@ -619,4 +619,10 @@ Batal - lanjutkan mengunduh</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} telah berubah sejak fix ini diterapkan, jadi memulihkannya akan menimpa perubahan tersebut. Jika Anda menerapkan fix lain di atasnya, kembalikan yang itu dulu. {1} berkas terpengaruh.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Perbaikan dikembalikan sebagian</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} berkas tidak dapat dipulihkan. Tutup game lalu coba lagi.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Sumber ini tidak memiliki gim ini, atau tidak dapat dijangkau.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Sumber manifest</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Sumber tambahan yang dideklarasikan dalam berkas .json. Hanya data: berkas menyebutkan dari mana manifest diambil, dan tidak ada isinya yang dijalankan.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Buka folder</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Belum ada berkas sumber.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>sumber: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.it.resx
+++ b/src/LuaToolsGui/Resources/Strings.it.resx
@@ -619,4 +619,10 @@ Annulla - continua a scaricare</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} è cambiato da quando questo fix è stato applicato, quindi ripristinarlo sovrascriverebbe quelle modifiche. Se hai applicato un altro fix sopra, ripristina prima quello. {1} file interessati.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Fix annullata parzialmente</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Impossibile ripristinare {0} file. Chiudi il gioco e riprova.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Questa fonte non ha questo gioco, o non è raggiungibile.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Fonti di manifest</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Fonti aggiuntive dichiarate in file .json. Solo dati: un file indica dove prendere i manifest, e nulla al suo interno viene mai eseguito.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Apri la cartella</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Nessun file di fonti per ora.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>fonti: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ja.resx
+++ b/src/LuaToolsGui/Resources/Strings.ja.resx
@@ -619,4 +619,10 @@ Steam\config\stplug-in から .lua ファイルを削除します。</value></da
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>この修正の適用後に {0} が変更されているため、復元するとその変更が上書きされます。別の修正を上に適用した場合は、先にそちらを元に戻してください。対象は {1} 個のファイルです。</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>修正は一部だけ元に戻りました</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} 個のファイルを復元できませんでした。ゲームを閉じてやり直してください。</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>このソースにはこのゲームがないか、接続できませんでした。</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>マニフェストのソース</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>​.json ファイルで宣言する追加ソース。データのみで、ファイルはマニフェストの取得先を示すだけです。中身が実行されることはありません。</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>フォルダーを開く</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>ソースファイルはまだありません。</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>ソース: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ko.resx
+++ b/src/LuaToolsGui/Resources/Strings.ko.resx
@@ -619,4 +619,10 @@ Steam\config\stplug-in에서 .lua 파일을 삭제합니다.</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>이 픽스를 적용한 뒤 {0} 이(가) 변경되어, 복원하면 해당 변경 사항을 덮어씁니다. 다른 픽스를 위에 적용했다면 그것부터 되돌리세요. {1}개 파일이 영향을 받습니다.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>수정이 일부만 되돌려졌습니다</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0}개 파일을 복원하지 못했습니다. 게임을 닫고 다시 시도하세요.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>이 소스에는 이 게임이 없거나 연결할 수 없습니다.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>매니페스트 소스</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>​.json 파일로 선언하는 추가 소스. 데이터일 뿐이며, 파일은 매니페스트를 어디서 가져올지 알려줄 뿐 그 안의 어떤 것도 실행되지 않습니다.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>폴더 열기</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>아직 소스 파일이 없습니다.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>소스: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.nb.resx
+++ b/src/LuaToolsGui/Resources/Strings.nb.resx
@@ -619,4 +619,10 @@ Avbryt - fortsett nedlastingen</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} er endret siden denne fiksen ble brukt, så gjenoppretting ville overskrive de endringene. Hvis du har brukt en annen fiks oppå, tilbakestill den først. {1} fil(er) berørt.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Rettelse delvis angret</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} fil(er) kunne ikke gjenopprettes. Lukk spillet og prøv igjen.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Denne kilden har ikke dette spillet, eller kunne ikke nås.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifestkilder</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Ekstra kilder angitt i .json-filer. Bare data: en fil sier hvor manifester hentes fra, og ingenting i den kjøres.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Åpne mappen</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Ingen kildefiler ennå.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>kilder: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.nl.resx
+++ b/src/LuaToolsGui/Resources/Strings.nl.resx
@@ -619,4 +619,10 @@ Annuleren - doorgaan met downloaden</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} is gewijzigd sinds deze fix is toegepast, dus herstellen zou die wijzigingen overschrijven. Als je er een andere fix overheen hebt toegepast, draai die dan eerst terug. {1} bestand(en) getroffen.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Fix gedeeltelijk teruggedraaid</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} bestand(en) konden niet worden hersteld. Sluit de game en probeer opnieuw.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Deze bron heeft dit spel niet, of was niet bereikbaar.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifestbronnen</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Extra bronnen, opgegeven in .json-bestanden. Alleen gegevens: een bestand zegt waar manifesten vandaan komen, er wordt nooit iets uit uitgevoerd.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Map openen</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Nog geen bronbestanden.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>bronnen: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pl.resx
+++ b/src/LuaToolsGui/Resources/Strings.pl.resx
@@ -619,4 +619,10 @@ Anuluj - kontynuuj pobieranie</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Plik {0} zmienił się od zastosowania tej poprawki, więc przywrócenie nadpisałoby te zmiany. Jeśli zastosowano na wierzchu inną poprawkę, cofnij najpierw ją. Dotyczy {1} plik(ów).</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Poprawka cofnięta częściowo</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Nie udało się przywrócić {0} plików. Zamknij grę i spróbuj ponownie.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>To źródło nie ma tej gry lub jest nieosiągalne.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Źródła manifestów</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Dodatkowe źródła zadeklarowane w plikach .json. Wyłącznie dane: plik mówi, skąd pobrać manifesty, i nic z niego nie jest uruchamiane.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Otwórz folder</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Brak plików źródeł.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>źródła: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pt-BR.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-BR.resx
@@ -619,4 +619,10 @@ Cancelar - continuar baixando</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} mudou desde que este fix foi aplicado, então restaurá-lo sobrescreveria essas mudanças. Se você aplicou outro fix por cima, reverta aquele primeiro. {1} arquivo(s) afetado(s).</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Correção revertida parcialmente</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Não foi possível restaurar {0} arquivo(s). Feche o jogo e tente novamente.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Esta fonte não tem este jogo, ou não pôde ser acessada.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Fontes de manifesto</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Fontes extras declaradas em arquivos .json. Apenas dados: um arquivo diz de onde buscar manifestos, e nada nele é executado.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Abrir a pasta</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Ainda não há arquivos de fontes.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>fontes: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.pt-PT.resx
+++ b/src/LuaToolsGui/Resources/Strings.pt-PT.resx
@@ -619,4 +619,10 @@ Cancelar - continuar a transferir</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} mudou desde que este fix foi aplicado, pelo que restaurá-lo iria sobrescrever essas alterações. Se aplicou outro fix por cima, reverta esse primeiro. {1} ficheiro(s) afetado(s).</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Correção revertida parcialmente</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Não foi possível restaurar {0} ficheiro(s). Feche o jogo e tente novamente.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Esta fonte não tem este jogo, ou não pôde ser contactada.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Fontes de manifesto</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Fontes adicionais declaradas em ficheiros .json. Apenas dados: um ficheiro diz onde obter manifestos, e nada nele é executado.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Abrir a pasta</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Ainda não há ficheiros de fontes.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>fontes: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.resx
+++ b/src/LuaToolsGui/Resources/Strings.resx
@@ -654,4 +654,10 @@ Cancel - keep downloading</value></data>
   <data name="Depot_Err_NoKeyFor" xml:space="preserve"><value>No decryption key in Lua for depot {0}.</value></data>
   <data name="Builds_Select_SharedHint" xml:space="preserve"><value>Shared runtime — usually already installed. Tick to download anyway.</value></data>
   <data name="Downloads_ClearHistory_Confirm" xml:space="preserve"><value>Remove all {0} entries from the download history? Downloaded files are not affected.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>This source doesn't have this game, or couldn't be reached.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifest sources</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Extra sources declared in .json files. Data only: a file says where manifests can be fetched from, and nothing in it is ever executed.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Open the folder</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>No source files yet.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>sources: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ro.resx
+++ b/src/LuaToolsGui/Resources/Strings.ro.resx
@@ -619,4 +619,10 @@ Anulare - continuă descărcarea</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} s-a modificat de la aplicarea acestui fix, așa că restaurarea ar suprascrie acele modificări. Dacă ai aplicat alt fix peste, anulează-l mai întâi pe acela. {1} fișier(e) afectate.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Reparație anulată parțial</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} fișier(e) nu au putut fi restaurate. Închide jocul și încearcă din nou.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Această sursă nu are acest joc sau nu a putut fi contactată.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Surse de manifeste</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Surse suplimentare declarate în fișiere .json. Doar date: un fișier spune de unde se iau manifestele și nimic din el nu se execută.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Deschide folderul</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Încă niciun fișier de surse.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>surse: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.ru.resx
+++ b/src/LuaToolsGui/Resources/Strings.ru.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Файл {0} изменился после применения этого фикса, и восстановление перезапишет эти изменения. Если поверх был применён другой фикс, сначала откатите его. Затронуто файлов: {1}.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Исправление откачено частично</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Не удалось восстановить файлов: {0}. Закройте игру и повторите попытку.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>В этом источнике нет этой игры, либо он недоступен.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Источники манифестов</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Дополнительные источники, описанные в файлах .json. Только данные: файл указывает, откуда брать манифесты, и ничего из него не выполняется.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Открыть папку</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Файлов источников пока нет.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>источники: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.sv.resx
+++ b/src/LuaToolsGui/Resources/Strings.sv.resx
@@ -619,4 +619,10 @@ Avbryt - fortsätt hämta</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} har ändrats sedan den här fixen tillämpades, så en återställning skulle skriva över de ändringarna. Om du tillämpat en annan fix ovanpå, återställ den först. {1} fil(er) påverkas.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Korrigering delvis ångrad</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} fil(er) kunde inte återställas. Stäng spelet och försök igen.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Den här källan har inte det här spelet, eller kunde inte nås.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifestkällor</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Extra källor som anges i .json-filer. Endast data: en fil säger var manifest hämtas, inget i den körs någonsin.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Öppna mappen</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Inga källfiler ännu.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>källor: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.th.resx
+++ b/src/LuaToolsGui/Resources/Strings.th.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} มีการเปลี่ยนแปลงหลังจากใช้แพตช์นี้ การกู้คืนจะเขียนทับการเปลี่ยนแปลงนั้น หากคุณใช้แพตช์อื่นทับไว้ ให้ย้อนกลับแพตช์นั้นก่อน มีไฟล์ที่ได้รับผลกระทบ {1} ไฟล์</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>ย้อนกลับตัวแก้ไขได้บางส่วน</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>กู้คืนไฟล์ {0} รายการไม่สำเร็จ กรุณาปิดเกมแล้วลองใหม่</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>แหล่งนี้ไม่มีเกมนี้ หรือเข้าถึงไม่ได้</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>แหล่งแมนิเฟสต์</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>แหล่งเพิ่มเติมที่ประกาศไว้ในไฟล์ .json เป็นข้อมูลล้วน ๆ ไฟล์บอกเพียงว่าจะดึงแมนิเฟสต์จากที่ใด และไม่มีอะไรในไฟล์ถูกรัน</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>เปิดโฟลเดอร์</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>ยังไม่มีไฟล์แหล่งข้อมูล</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>แหล่ง: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.tr.resx
+++ b/src/LuaToolsGui/Resources/Strings.tr.resx
@@ -619,4 +619,10 @@ Hayır - durdur ama dosyaları koru
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Bu düzeltme uygulandıktan sonra {0} değişti; geri yüklemek bu değişikliklerin üzerine yazar. Üstüne başka bir düzeltme uyguladıysanız önce onu geri alın. {1} dosya etkilendi.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Düzeltme kısmen geri alındı</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} dosya geri yüklenemedi. Oyunu kapatıp tekrar deneyin.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Bu kaynakta bu oyun yok ya da kaynağa ulaşılamadı.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Manifest kaynakları</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>​.json dosyalarında tanımlanan ek kaynaklar. Yalnızca veri: dosya manifestlerin nereden alınacağını söyler, içinden hiçbir şey çalıştırılmaz.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Klasörü aç</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Henüz kaynak dosyası yok.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>kaynaklar: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.uk.resx
+++ b/src/LuaToolsGui/Resources/Strings.uk.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>Файл {0} змінився після застосування цього фікса, тож відновлення перезапише ці зміни. Якщо згори застосовано інший фікс, спершу скасуйте його. Порушено файлів: {1}.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Виправлення відкочено частково</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Не вдалося відновити файлів: {0}. Закрийте гру та спробуйте ще раз.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>У цьому джерелі немає цієї гри, або воно недоступне.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Джерела маніфестів</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Додаткові джерела, описані у файлах .json. Лише дані: файл вказує, звідки брати маніфести, і нічого з нього не виконується.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Відкрити теку</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Файлів джерел поки немає.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>джерела: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.vi.resx
+++ b/src/LuaToolsGui/Resources/Strings.vi.resx
@@ -619,4 +619,10 @@ Hủy - tiếp tục tải</value></data>
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>{0} đã thay đổi kể từ khi bản vá này được áp dụng, nên khôi phục sẽ ghi đè các thay đổi đó. Nếu bạn đã áp dụng bản vá khác lên trên, hãy hoàn tác bản đó trước. {1} tệp bị ảnh hưởng.</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Bản sửa lỗi được hoàn tác một phần</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>Không thể khôi phục {0} tệp. Hãy đóng trò chơi và thử lại.</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>Nguồn này không có trò chơi này, hoặc không kết nối được.</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>Nguồn manifest</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>Nguồn bổ sung khai báo trong tệp .json. Chỉ là dữ liệu: tệp cho biết lấy manifest ở đâu, và không có gì trong đó được thực thi.</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>Mở thư mục</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>Chưa có tệp nguồn nào.</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>nguồn: {0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hans.resx
@@ -639,4 +639,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>自应用此修复以来，{0} 已被更改，还原会覆盖这些更改。如果你在其上应用了另一个修复，请先还原那一个。共影响 {1} 个文件。</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>修复部分还原</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>有 {0} 个文件无法恢复。请关闭游戏后重试。</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>此来源没有这个游戏，或无法连接。</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>清单来源</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>在 .json 文件中声明的额外来源。纯数据：文件只说明从哪里获取清单，其中的任何内容都不会被执行。</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>打开文件夹</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>还没有来源文件。</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>来源：{0}</value></data>
 </root>

--- a/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
+++ b/src/LuaToolsGui/Resources/Strings.zh-Hant.resx
@@ -619,4 +619,10 @@
   <data name="Fixes_Revert_Conflict_Body" xml:space="preserve"><value>自套用此修復以來，{0} 已被變更，還原會覆寫這些變更。如果你在其上套用了另一個修復，請先還原那一個。共影響 {1} 個檔案。</value></data>
   <data name="Fixes_Revert_Partial" xml:space="preserve"><value>修復部分還原</value></data>
   <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>有 {0} 個檔案無法復原。請關閉遊戲後重試。</value></data>
+  <data name="Sources_Err_Fetch" xml:space="preserve"><value>此來源沒有這個遊戲，或無法連線。</value></data>
+  <data name="Settings_Section_Sources" xml:space="preserve"><value>資訊清單來源</value></data>
+  <data name="Settings_SourcePacks_Hint" xml:space="preserve"><value>在 .json 檔案中宣告的額外來源。純資料：檔案只說明從何處取得資訊清單，其中的任何內容都不會被執行。</value></data>
+  <data name="Settings_SourcePacks_Open" xml:space="preserve"><value>開啟資料夾</value></data>
+  <data name="Settings_SourcePacks_None" xml:space="preserve"><value>尚未有來源檔案。</value></data>
+  <data name="Settings_SourcePacks_Count" xml:space="preserve"><value>來源：{0}</value></data>
 </root>

--- a/src/LuaToolsGui/Services/Downloads/ManifestJobFactory.cs
+++ b/src/LuaToolsGui/Services/Downloads/ManifestJobFactory.cs
@@ -25,7 +25,8 @@ public class ManifestJobFactory(
     DepotDownloaderService depotTool,
     SteamDepotInfo depotInfo,
     SteamAutoCrackService sac,
-    AppliedFixIndexService fixIndex)
+    AppliedFixIndexService fixIndex,
+    Sources.PackSourceService packSources)
 {
     // ── Job builders ─────────────────────────────────────────────────
 
@@ -47,6 +48,32 @@ public class ManifestJobFactory(
             (_, progress, ct) => needsKey
                 ? hubcap.DownloadManifestAsync(appId.ToString(), settings.HubcapApiKey ?? "", progress, ct)
                 : api.DownloadManifestAsync(appId.ToString(), sourceName, gameName, progress, ct),
+            (file, _, _) => Task.FromResult(InstallManifest(file, appId, title)),
+            confirm,
+            onFinished,
+            onReveal);
+    }
+
+    /// <summary>
+    /// A manifest from a source a pack declared. Fetched from the pack's url, then installed by exactly
+    /// the same code as any other manifest — a pack changes where a file comes from, never what is done
+    /// with it.
+    /// </summary>
+    public DownloadJob CreatePackSourceJob(
+        Sources.PackSource source, long appId, string? gameName,
+        Func<DownloadedFile, DownloadItem, CancellationToken, Task<bool>>? confirm = null,
+        Action<DownloadItem, JobResult?>? onFinished = null,
+        Action? onReveal = null)
+    {
+        string title = gameName ?? appId.ToString();
+        return new DownloadJob(
+            DownloadKind.Manifest,
+            $"manifest:{appId}",
+            appId,
+            title,
+            source.DisplayName,
+            covers.GetLocalPath(appId),
+            (_, progress, ct) => packSources.FetchAsync(source, appId, progress, ct),
             (file, _, _) => Task.FromResult(InstallManifest(file, appId, title)),
             confirm,
             onFinished,

--- a/src/LuaToolsGui/Services/Sources/PackSourceService.cs
+++ b/src/LuaToolsGui/Services/Sources/PackSourceService.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using LuaToolsGui.Services.Downloads;
+using Microsoft.Extensions.Logging;
+
+namespace LuaToolsGui.Services.Sources;
+
+/// <summary>
+/// Fetches from the manifest sources a pack declared. One service for all of them, because a pack names
+/// a SHAPE the app already knows how to consume rather than supplying a routine of its own.
+/// </summary>
+/// <remarks>
+/// Everything goes through <see cref="GithubProxy"/>, the existence probe included: the proxy tries the
+/// url directly and only then its mirrors, so a probe that skipped it would answer "this source doesn't
+/// have the game" whenever GitHub was blocked, while the download that followed would have succeeded
+/// through a mirror.
+/// </remarks>
+public class PackSourceService(GithubProxy gh, ILogger<PackSourceService> log)
+{
+    // Its own client so a probe never inherits a long download timeout.
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(15) };
+
+    /// <summary>Does this source have the game? Any failure answers "no", never an error.</summary>
+    public async Task<bool> HasGameAsync(PackSource source, long appId, CancellationToken ct = default)
+    {
+        try
+        {
+            foreach (string url in Urls(source, appId))
+                foreach (string candidate in GithubProxy.Candidates(url))
+                {
+                    try { if (await ExistsAsync(candidate, ct)) return true; }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+                    catch { /* this candidate is out; the next one may answer */ }
+                }
+
+            return false;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            log.LogDebug(ex, "Pack source {Source} probe for {AppId} failed", source.Name, appId);
+            return false;
+        }
+    }
+
+    /// <summary>Fetch the game to a temp file, for the existing install pipeline to take.</summary>
+    public async Task<DownloadedFile> FetchAsync(
+        PackSource source, long appId, IProgress<DownloadProgress>? progress, CancellationToken ct = default)
+    {
+        string ext = source.Kind is SourceKind.ManifestZip ? "zip" : "lua";
+        string path = Path.Combine(Path.GetTempPath(), $"pack-{Sanitize(source.Name)}-{appId}.{ext}");
+
+        // GithubProxy reports 0..1 fractions; scaled to the byte-shaped report the queue's UI speaks, so
+        // the bar moves rather than sitting still.
+        var sink = progress is null ? null
+            : new ProgressRelay<double?>(f => progress.Report(new DownloadProgress((long)((f ?? 0) * 1000), 1000)));
+
+        Exception? last = null;
+        foreach (string url in Urls(source, appId))
+        {
+            try
+            {
+                await gh.DownloadAsync(url, path, sink, ct);
+                if (File.Exists(path) && new FileInfo(path).Length > 0)
+                    return new DownloadedFile(path, $"{appId}.{ext}");
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex) { last = ex; }
+        }
+
+        log.LogDebug(last, "Pack source {Source} could not fetch {AppId}", source.Name, appId);
+        throw new DownloadAbortedException(Resources.Strings.Sources_Err_Fetch);
+    }
+
+    /// <summary>
+    /// Does this exact url serve something? HEAD first, and on a host that refuses HEAD, a one-byte
+    /// ranged GET — a pack's url is any host its author chose, and plenty answer 405 or 501 to a HEAD
+    /// while serving the file perfectly well over GET.
+    /// </summary>
+    private async Task<bool> ExistsAsync(string url, CancellationToken ct)
+    {
+        using var head = new HttpRequestMessage(HttpMethod.Head, url);
+        head.Headers.TryAddWithoutValidation("User-Agent", "LuaTools");
+        using var headRes = await _http.SendAsync(head, ct);
+        if (headRes.StatusCode == HttpStatusCode.OK) return true;
+        if (headRes.StatusCode is not (HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented))
+            return false;
+
+        // Range is a request, not a promise: a server may ignore it and start sending the whole file, so
+        // the response is disposed without reading the body and only the status is used.
+        using var get = new HttpRequestMessage(HttpMethod.Get, url);
+        get.Headers.TryAddWithoutValidation("User-Agent", "LuaTools");
+        get.Headers.TryAddWithoutValidation("Range", "bytes=0-0");
+        using var getRes = await _http.SendAsync(get, HttpCompletionOption.ResponseHeadersRead, ct);
+        return getRes.StatusCode is HttpStatusCode.OK or HttpStatusCode.PartialContent;
+    }
+
+    private static IEnumerable<string> Urls(PackSource source, long appId)
+    {
+        yield return Fill(source.Url, appId);
+        foreach (string m in source.Mirrors) yield return Fill(m, appId);
+    }
+
+    private static string Fill(string template, long appId) =>
+        template.Replace("{appid}", appId.ToString(), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Keeps a pack-supplied name fit for a temp file name.</summary>
+    private static string Sanitize(string name) =>
+        string.Concat(name.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c));
+}

--- a/src/LuaToolsGui/Services/Sources/SourcePack.cs
+++ b/src/LuaToolsGui/Services/Sources/SourcePack.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+
+namespace LuaToolsGui.Services.Sources;
+
+/// <summary>
+/// One <c>.json</c> file in the source-pack folder. Pure data: a pack declares where manifests can be
+/// fetched from and nothing else. There is no code path here by design — a pack cannot execute anything,
+/// which is what makes it safe to install one from someone you don't know.
+/// </summary>
+public sealed class SourcePack
+{
+    /// <summary>
+    /// Format version of the file. Bumped only when a change would make an older build misread a newer
+    /// pack; a build refuses a schema from the future rather than guess at what it means.
+    /// </summary>
+    [JsonPropertyName("schema")]
+    public int Schema { get; set; } = 1;
+
+    /// <summary>Shown in the pack list. Falls back to the file name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("author")]
+    public string? Author { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("sources")]
+    public List<SourceEntry> Sources { get; set; } = [];
+}
+
+/// <summary>The shapes of source LuaTools knows how to fetch. A pack picks one; it cannot supply its own.</summary>
+public enum SourceKind
+{
+    /// <summary>One <c>&lt;appid&gt;.zip</c> per game, holding the lua and its <c>.manifest</c> files.</summary>
+    ManifestZip,
+
+    /// <summary>One <c>&lt;appid&gt;.lua</c> per game: entitlements and depot keys, no manifests.</summary>
+    LuaFile,
+}
+
+/// <summary>A single source declared by a pack.</summary>
+public sealed class SourceEntry
+{
+    /// <summary>
+    /// Key used for the row, ordering and the download route. Must not be one the app already uses —
+    /// a pack that claims an existing name is refused rather than silently shadowing it.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>What the Add page's row shows. Falls back to <see cref="Name"/>.</summary>
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>"manifestZip" or "luaFile", case-insensitive.</summary>
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; } = "";
+
+    /// <summary>Where to fetch, containing the literal token <c>{appid}</c>.</summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
+
+    /// <summary>
+    /// Tried in order when the primary url is unreachable. The reason packs are worth having at all: a
+    /// repo that moves or goes stale becomes a line to edit rather than a release to cut.
+    /// </summary>
+    [JsonPropertyName("mirrors")]
+    public List<string> Mirrors { get; set; } = [];
+
+    /// <summary>Short label on the row. Cosmetic; the app never reads it back as a capability.</summary>
+    [JsonPropertyName("badge")]
+    public string? Badge { get; set; }
+}

--- a/src/LuaToolsGui/Services/Sources/SourcePackRegistry.cs
+++ b/src/LuaToolsGui/Services/Sources/SourcePackRegistry.cs
@@ -1,0 +1,158 @@
+using System.IO;
+using System.Text.Json;
+
+namespace LuaToolsGui.Services.Sources;
+
+/// <summary>A source a pack declared, after the registry has vetted it.</summary>
+public sealed record PackSource(
+    string Name,
+    string DisplayName,
+    SourceKind Kind,
+    string Url,
+    IReadOnlyList<string> Mirrors,
+    string? Badge);
+
+/// <summary>One pack file, and what became of it.</summary>
+public sealed class LoadedPack
+{
+    public required string FileName { get; init; }
+    public required string DisplayName { get; init; }
+    public string? Author { get; init; }
+    public string? Description { get; init; }
+
+    /// <summary>Null when the pack loaded; otherwise why it was refused, in words for the user.</summary>
+    public string? Error { get; set; }
+
+    public List<PackSource> Sources { get; } = [];
+}
+
+/// <summary>
+/// Reads manifest sources from <c>%AppData%\LuaToolsGui\sources\*.json</c>.
+/// </summary>
+/// <remarks>
+/// <para>The sources this app can fetch from are otherwise fixed at build time, so following one to a
+/// fresher mirror — or adding a community repo at all — means cutting a release. A pack file moves that
+/// to editing a line of JSON.</para>
+///
+/// <para>A pack is <b>data only</b>. There is deliberately no way for one to supply code, a binary or a
+/// fetch routine of its own: it names one of the shapes the app already knows how to consume, and the
+/// app does the fetching. Installing a pack from a stranger cannot execute anything.</para>
+///
+/// <para>Nothing here may stop the app from starting. Every stage is wrapped, a bad file is recorded
+/// against its own name and the loop moves on.</para>
+/// </remarks>
+public sealed class SourcePackRegistry
+{
+    /// <summary>Highest pack schema this build understands.</summary>
+    private const int SupportedSchema = 1;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    public static string Root { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LuaToolsGui", "sources");
+
+    private readonly List<LoadedPack> _packs = [];
+
+    /// <summary>Every pack file found, loaded or refused.</summary>
+    public IReadOnlyList<LoadedPack> Packs => _packs;
+
+    /// <summary>Sources contributed by the packs that loaded, in file then declaration order.</summary>
+    public IReadOnlyList<PackSource> Sources => _packs.SelectMany(p => p.Sources).ToList();
+
+    /// <summary>
+    /// Re-read the folder. Cheap (a handful of small files) and safe to call whenever the list might
+    /// have changed, which is what lets a pack be added without restarting the app.
+    /// </summary>
+    /// <param name="reservedNames">
+    /// Source names the app already uses. A pack claiming one is refused rather than shadowing it: a row
+    /// whose behaviour depended on which registration won would be impossible to reason about.
+    /// </param>
+    public void Reload(IReadOnlyCollection<string> reservedNames)
+    {
+        _packs.Clear();
+
+        List<string> files;
+        try
+        {
+            if (!Directory.Exists(Root)) return;
+            files = Directory.EnumerateFiles(Root, "*.json").OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+        catch { return; }
+
+        var taken = new HashSet<string>(reservedNames, StringComparer.OrdinalIgnoreCase);
+
+        foreach (string file in files)
+        {
+            string shown = Path.GetFileName(file);
+            SourcePack? pack;
+            try { pack = JsonSerializer.Deserialize<SourcePack>(File.ReadAllText(file), JsonOpts); }
+            catch (Exception ex)
+            {
+                _packs.Add(new LoadedPack { FileName = shown, DisplayName = shown, Error = ex.Message });
+                continue;
+            }
+
+            if (pack is null)
+            {
+                _packs.Add(new LoadedPack { FileName = shown, DisplayName = shown, Error = "the file is empty" });
+                continue;
+            }
+
+            var loaded = new LoadedPack
+            {
+                FileName = shown,
+                DisplayName = string.IsNullOrWhiteSpace(pack.Name) ? shown : pack.Name!,
+                Author = pack.Author,
+                Description = pack.Description,
+            };
+            _packs.Add(loaded);
+
+            if (pack.Schema > SupportedSchema)
+            {
+                loaded.Error = $"needs a newer LuaTools (schema {pack.Schema}, this build reads {SupportedSchema})";
+                continue;
+            }
+
+            foreach (var e in pack.Sources) Vet(loaded, e, taken);
+        }
+    }
+
+    /// <summary>Adds one declared source, or records why it was skipped. Never throws.</summary>
+    private static void Vet(LoadedPack pack, SourceEntry e, HashSet<string> taken)
+    {
+        void Skip(string why) => pack.Error = pack.Error is null ? why : $"{pack.Error}; {why}";
+
+        if (string.IsNullOrWhiteSpace(e.Name) || string.IsNullOrWhiteSpace(e.Url))
+        { Skip("a source is missing its name or url"); return; }
+
+        if (!Enum.TryParse<SourceKind>(e.Kind, ignoreCase: true, out var kind))
+        { Skip($"\"{e.Name}\" has an unknown kind \"{e.Kind}\""); return; }
+
+        // Everything a pack fetches goes over TLS. A source anyone can add is not the place to accept
+        // plaintext: the file it returns is installed into Steam.
+        if (!IsHttps(e.Url) || e.Mirrors.Any(u => !IsHttps(u)))
+        { Skip($"\"{e.Name}\" must use https"); return; }
+
+        if (!e.Url.Contains("{appid}", StringComparison.OrdinalIgnoreCase))
+        { Skip($"\"{e.Name}\" has no {{appid}} in its url"); return; }
+
+        if (!taken.Add(e.Name))
+        { Skip($"\"{e.Name}\" is a name the app already uses"); return; }
+
+        pack.Sources.Add(new PackSource(
+            e.Name,
+            string.IsNullOrWhiteSpace(e.DisplayName) ? e.Name : e.DisplayName!,
+            kind,
+            e.Url,
+            e.Mirrors.Where(IsHttps).ToArray(),
+            e.Badge));
+    }
+
+    private static bool IsHttps(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var u) && u.Scheme == Uri.UriSchemeHttps;
+}

--- a/src/LuaToolsGui/ViewModels/DownloadViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/DownloadViewModel.cs
@@ -46,13 +46,17 @@ public partial class SourceRowViewModel : ObservableObject
     // would collapse it anyway; this just keeps the button from looking clickable.
     public bool CanDownload => IsAvailable && !IsLocked && QueueItem?.IsActive != true;
 
-    public SourceRowViewModel(DownloadViewModel parent, string name, string status)
+    /// <param name="displayName">
+    /// Overrides the source-meta table. A source declared by a pack is not in it and never will be —
+    /// its label travels with the declaration.
+    /// </param>
+    public SourceRowViewModel(DownloadViewModel parent, string name, string status, string? displayName = null)
     {
         _parent = parent;
         Name = name;
         Status = status;
         var meta = SourceMeta.Get(name);
-        DisplayName = meta.DisplayName ?? name;
+        DisplayName = displayName ?? meta.DisplayName ?? name;
         DiscordUrl = meta.DiscordUrl;
         NeedsKey = meta.RequiresUserKey;
     }
@@ -89,6 +93,8 @@ public partial class DownloadViewModel : ObservableObject
     private readonly HardwareAppIdService _hardware;
     private readonly DownloadQueue _queue;
     private readonly ManifestJobFactory _jobs;
+    private readonly Services.Sources.SourcePackRegistry _packs;
+    private readonly Services.Sources.PackSourceService _packSources;
     private CancellationTokenSource? _searchCts;
     private CancellationTokenSource? _detailsCts;
 
@@ -324,8 +330,11 @@ public partial class DownloadViewModel : ObservableObject
         AuthService auth, ToastService toast, LuaInstaller installer,
         SteamAppListCache appList, SteamAppInfoCache appInfo, SteamDepotInfo depotInfo,
         HardwareAppIdService hardware, DropInstallViewModel drop,
-        DownloadQueue queue, ManifestJobFactory jobs)
+        DownloadQueue queue, ManifestJobFactory jobs,
+        Services.Sources.SourcePackRegistry packs, Services.Sources.PackSourceService packSources)
     {
+        _packs = packs;
+        _packSources = packSources;
         _api = api;
         _hubcap = hubcap;
         _settings = settings;
@@ -543,6 +552,8 @@ public partial class DownloadViewModel : ObservableObject
                 foreach (var (name, status) in statuses.OrderByDescending(kv => SourceMeta.Get(kv.Key).RequiresUserKey ? 1 : 0))
                     Sources.Add(new SourceRowViewModel(this, name, status));
 
+                await AddPackSourcesAsync(Details.AppId);
+
                 await ApplyHubcapStateAsync();
 
                 if (FastFetch)
@@ -667,8 +678,14 @@ public partial class DownloadViewModel : ObservableObject
 
         // Hubcap downloads use the user's OWN key and never touch lua.tools, so a guest with a key
         // configured can download without signing in. Every other source still needs a lua.tools account.
+        // A pack source is fetched straight from the url its file names and never touches lua.tools, so
+        // a lua.tools account has no bearing on it. Resolved before the gate for that reason.
+        var packSource = _packs.Sources.FirstOrDefault(x =>
+            string.Equals(x.Name, source.Name, StringComparison.OrdinalIgnoreCase));
+
         bool hubcapWithKey = source.NeedsKey && !string.IsNullOrEmpty(_settings.HubcapApiKey);
-        if (!hubcapWithKey && await PromptSignInIfGuestAsync(Resources.Strings.Add_SignIn_Download)) return null;
+        if (!hubcapWithKey && packSource is null
+            && await PromptSignInIfGuestAsync(Resources.Strings.Add_SignIn_Download)) return null;
 
         Error = null;
         LastDownload = null;
@@ -680,17 +697,62 @@ public partial class DownloadViewModel : ObservableObject
         string gameName = Details.Name;
         bool needsKey = source.NeedsKey;
 
-        var job = _jobs.CreateManifestJob(
-            appId, gameName, source.Name, needsKey,
-            // Silent/headless installs have no surfaced window to confirm on, so they skip the gate.
-            confirm: _silentInstall ? null : (file, _, ct) => ConfirmOverwriteAsync(file, appId, gameName, ct),
-            onFinished: (item, result) => OnManifestFinished(item, result, needsKey),
-            onReveal: () => NavigateToGame?.Invoke(appId));
+        // Silent/headless installs have no surfaced window to confirm on, so they skip the gate.
+        Func<DownloadedFile, DownloadItem, CancellationToken, Task<bool>>? confirm =
+            _silentInstall ? null : (file, _, ct) => ConfirmOverwriteAsync(file, appId, gameName, ct);
+
+        var job = packSource is not null
+            ? _jobs.CreatePackSourceJob(packSource, appId, gameName,
+                confirm: confirm,
+                onFinished: (item, result) => OnManifestFinished(item, result, needsKey: false),
+                onReveal: () => NavigateToGame?.Invoke(appId))
+            : _jobs.CreateManifestJob(
+                appId, gameName, source.Name, needsKey,
+                confirm: confirm,
+                onFinished: (item, result) => OnManifestFinished(item, result, needsKey),
+                onReveal: () => NavigateToGame?.Invoke(appId));
 
         var queued = _queue.Enqueue(job);
         source.QueueItem = queued;
         _lastEnqueued = queued;
         return queued;
+    }
+
+    /// <summary>
+    /// Append a row for every pack-declared source that has this game.
+    /// </summary>
+    /// <remarks>
+    /// Appended after the app's own sources rather than ranked among them: their order is a decision
+    /// this app makes, and a file the user dropped in a folder should not be able to overturn it.
+    /// Probed in parallel, because the count is whatever the user installed and doing them in sequence
+    /// would put a pack's latency on the critical path of every fetch. A probe that fails means "this
+    /// source doesn't have it", never an error.
+    /// </remarks>
+    private async Task AddPackSourcesAsync(long appId)
+    {
+        _packs.Reload(SourceMeta.All.Keys.ToList());
+
+        var sources = _packs.Sources;
+        if (sources.Count == 0) return;
+
+        var probes = sources.Select(src => (Source: src, Has: SafeHasAsync(src, appId))).ToList();
+        await Task.WhenAll(probes.Select(p => p.Has));
+
+        foreach (var (src, has) in probes)
+        {
+            if (!has.Result) continue;
+            Sources.Add(new SourceRowViewModel(this, src.Name, "available", src.DisplayName)
+            {
+                StatsText = src.Badge,
+            });
+        }
+    }
+
+    /// <summary>A HasGameAsync that never throws: a failed or offline lookup just means "not covered".</summary>
+    private async Task<bool> SafeHasAsync(Services.Sources.PackSource src, long appId)
+    {
+        try { return await _packSources.HasGameAsync(src, appId); }
+        catch { return false; }
     }
 
     /// <summary>DLC lua: download and install silently (it's just an unlock, no confirm).</summary>

--- a/src/LuaToolsGui/ViewModels/SettingsViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/SettingsViewModel.cs
@@ -18,6 +18,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly AuthService _auth;
     private readonly SteamService _steam;
     private readonly HubcapService _hubcap;
+    private readonly Services.Sources.SourcePackRegistry _packs;
 
     [ObservableProperty] private string? _displayName;
     [ObservableProperty] private string? _email;
@@ -222,8 +223,9 @@ public partial class SettingsViewModel : ObservableObject
     public Action? RequestRestartPrompt { get; set; }
 
     public SettingsViewModel(SettingsService settings, AuthService auth, SteamService steam,
-        HubcapService hubcap)
+        HubcapService hubcap, Services.Sources.SourcePackRegistry packs)
     {
+        _packs = packs;
         _settings = settings;
         _auth = auth;
         _steam = steam;
@@ -366,6 +368,10 @@ public partial class SettingsViewModel : ObservableObject
         // that only read the setting at construction). No-op if unchanged; a real change writes back the
         // same value, so no feedback loop.
         FastFetch = _settings.FastFetch;
+
+        // Re-read the source-pack folder every time the page is shown: dropping a file in and coming
+        // back here to check it was accepted is the natural gesture. Cheap - a handful of small files.
+        RefreshSourcePacks();
     }
 
     /// <summary>Re-fetch usage stats for the saved key. Silent no-op if no key is saved.</summary>
@@ -450,5 +456,42 @@ public partial class SettingsViewModel : ObservableObject
             return string.Format(Resources.Strings.Settings_HubcapKeyOkExpiry, stats.DailyUsage, stats.DailyLimit,
                 expiry.ToString("yyyy-MM-dd"));
         return usage;
+    }
+    // ── Manifest source packs ────────────────────────────────────────
+
+    /// <summary>One line per .json file found: what it contributed, or why it was refused.</summary>
+    public System.Collections.ObjectModel.ObservableCollection<string> SourcePacks { get; } = [];
+
+    public bool HasSourcePacks => SourcePacks.Count > 0;
+
+    /// <summary>
+    /// Re-read the source-pack folder. Called when the page is shown, so dropping a file in and coming
+    /// back here is enough to see whether it was accepted - no restart, since a pack is only ever data.
+    /// </summary>
+    public void RefreshSourcePacks()
+    {
+        _packs.Reload(Models.SourceMeta.All.Keys.ToList());
+
+        SourcePacks.Clear();
+        foreach (var pack in _packs.Packs)
+        {
+            string detail = pack.Error is not null
+                ? pack.Error
+                : string.Format(Resources.Strings.Settings_SourcePacks_Count, pack.Sources.Count);
+            SourcePacks.Add($"{pack.DisplayName} — {detail}");
+        }
+        OnPropertyChanged(nameof(HasSourcePacks));
+    }
+
+    [RelayCommand]
+    private void OpenSourcesFolder()
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(Services.Sources.SourcePackRegistry.Root);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(
+                Services.Sources.SourcePackRegistry.Root) { UseShellExecute = true });
+        }
+        catch { /* opening a folder is never worth an error dialog */ }
     }
 }

--- a/src/LuaToolsGui/Views/SettingsView.xaml
+++ b/src/LuaToolsGui/Views/SettingsView.xaml
@@ -551,6 +551,45 @@
                         IsChecked="{Binding DonateKeys, Mode=TwoWay}" />
                 </Grid>
             </Border>
+
+            <!-- Manifest sources -->
+            <TextBlock Style="{StaticResource SectionHeader}" Text="{x:Static res:Strings.Settings_Section_Sources}" />
+            <Border Style="{StaticResource SettingsCard}">
+                <StackPanel Margin="14,12">
+                    <TextBlock
+                        FontSize="12"
+                        Foreground="#6b7280"
+                        Text="{x:Static res:Strings.Settings_SourcePacks_Hint}"
+                        TextWrapping="Wrap" />
+
+                    <!-- One line per file. No inner scroller: a nested one marks every wheel event
+                         handled, even at its own end, and traps the wheel for the page below it. -->
+                    <ItemsControl Margin="0,10,0,0" ItemsSource="{Binding SourcePacks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Margin="0,0,0,3"
+                                    FontSize="12"
+                                    Text="{Binding}"
+                                    TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock
+                        FontSize="12"
+                        Foreground="#6b7280"
+                        Text="{x:Static res:Strings.Settings_SourcePacks_None}"
+                        Visibility="{Binding HasSourcePacks, Converter={StaticResource InverseBoolToVis}}" />
+
+                    <ui:Button
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Left"
+                        Command="{Binding OpenSourcesFolderCommand}"
+                        Content="{x:Static res:Strings.Settings_SourcePacks_Open}"
+                        Icon="{ui:SymbolIcon FolderOpen24}" />
+                </StackPanel>
+            </Border>
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
As discussed — the JSON half only. **No plugin loader, no dll, nothing loaded.**

A `.json` file under `%AppData%\LuaToolsGui\sources\` declares extra manifest sources. They appear as rows on the **Add** page and install through the existing pipeline.

```json
{
  "schema": 1,
  "name": "Example sources",
  "sources": [{
    "name": "example-zip",
    "displayName": "Example",
    "kind": "manifestZip",
    "url": "https://raw.githubusercontent.com/someone/some-repo/main/{appid}.zip",
    "badge": "Free"
  }]
}
```

**Why:** the sources the app can fetch from are fixed at build time, so following a repo that moved means cutting a release. This makes it a line of JSON.

**A file can only say *where* manifests come from.** It names one of two shapes the app already consumes — `manifestZip` (`<appid>.zip`) or `luaFile` (`<appid>.lua`) — and the app does the fetching. There is no way for one to supply code, a binary, or a routine of its own, so installing one from a stranger cannot execute anything.

Three choices worth flagging for review:

- Rows are **appended after** the app's own sources rather than ranked among them. That order is yours to decide, not a dropped-in file's.
- They're exempt from the lua.tools sign-in gate, since they're fetched from the url the file names and never touch lua.tools.
- The availability probe goes through `GithubProxy` like the download does — one that skipped it would report "doesn't have the game" whenever GitHub was blocked, while the download would have gone through a mirror. Hosts that refuse `HEAD` get a one-byte ranged `GET`.

Refusals (a name already in use, non-https, missing `{appid}`, unknown `kind`) are listed in **Settings → Manifest sources** with the reason; one bad entry doesn't take a file's good ones with it. Files are re-read when that page opens, so no restart.

All 29 languages. Format documented in `SOURCES.md`. Happy to change any of it, or drop it if you'd rather not have the surface.
