### PR TITLE
add revert for applied fixes

### DIFF
--- a/src/LuaToolsGui/Models/FixModels.cs
+++ b/src/LuaToolsGui/Models/FixModels.cs
@@ -56,3 +56,20 @@ public class DenuvoDownloadResponse
 {
     [JsonPropertyName("url")] public string Url { get; set; } = "";
 }
+
+// ── Fix revert manifest (written to .luatools-fix/ inside the game folder) ──
+
+public class DenuvoFixManifest
+{
+    [JsonPropertyName("appId")] public long AppId { get; set; }
+    [JsonPropertyName("fixId")] public string FixId { get; set; } = "";
+    [JsonPropertyName("appliedAt")] public string AppliedAt { get; set; } = "";
+    [JsonPropertyName("files")] public List<DenuvoFixManifestEntry> Files { get; set; } = [];
+}
+
+public class DenuvoFixManifestEntry
+{
+    [JsonPropertyName("relativePath")] public string RelativePath { get; set; } = "";
+    [JsonPropertyName("action")] public string Action { get; set; } = ""; // "modified" or "added"
+    [JsonPropertyName("backupPath")] public string? BackupPath { get; set; } // relative to .luatools-fix/
+}

--- a/src/LuaToolsGui/Resources/Strings.Designer.cs
+++ b/src/LuaToolsGui/Resources/Strings.Designer.cs
@@ -298,6 +298,17 @@ public static class Strings
     public static string Fixes_Toast_CouldntApply => Get(nameof(Fixes_Toast_CouldntApply));
     public static string Fixes_Toast_Refreshed_Title => Get(nameof(Fixes_Toast_Refreshed_Title));
     public static string Fixes_Toast_Refreshed_Body => Get(nameof(Fixes_Toast_Refreshed_Body));
+    public static string Fixes_Revert => Get(nameof(Fixes_Revert));
+    public static string Fixes_Revert_Cancel => Get(nameof(Fixes_Revert_Cancel));
+    public static string Fixes_Revert_Confirm_Title => Get(nameof(Fixes_Revert_Confirm_Title));
+    public static string Fixes_Revert_Confirm_Body => Get(nameof(Fixes_Revert_Confirm_Body));
+    public static string Fixes_Revert_Done => Get(nameof(Fixes_Revert_Done));
+    public static string Fixes_Revert_Done_Body => Get(nameof(Fixes_Revert_Done_Body));
+    public static string Fixes_Revert_Partial => Get(nameof(Fixes_Revert_Partial));
+    public static string Fixes_Revert_Partial_Body => Get(nameof(Fixes_Revert_Partial_Body));
+    public static string Fixes_Revert_Failed => Get(nameof(Fixes_Revert_Failed));
+    public static string Fixes_Revert_NoManifest => Get(nameof(Fixes_Revert_NoManifest));
+    public static string Fixes_Applied_Hint => Get(nameof(Fixes_Applied_Hint));
 
     // ── Add / Download ──
     public static string Add_Title => Get(nameof(Add_Title));

--- a/src/LuaToolsGui/Resources/Strings.Designer.cs
+++ b/src/LuaToolsGui/Resources/Strings.Designer.cs
@@ -309,6 +309,9 @@ public static class Strings
     public static string Fixes_Revert_Failed => Get(nameof(Fixes_Revert_Failed));
     public static string Fixes_Revert_NoManifest => Get(nameof(Fixes_Revert_NoManifest));
     public static string Fixes_Applied_Hint => Get(nameof(Fixes_Applied_Hint));
+    public static string Fixes_MyGames => Get(nameof(Fixes_MyGames));
+    public static string Fixes_MyGames_Count => Get(nameof(Fixes_MyGames_Count));
+    public static string Fixes_MyGames_NotInstalled => Get(nameof(Fixes_MyGames_NotInstalled));
 
     // ── Add / Download ──
     public static string Add_Title => Get(nameof(Add_Title));

--- a/src/LuaToolsGui/Resources/Strings.es.resx
+++ b/src/LuaToolsGui/Resources/Strings.es.resx
@@ -326,6 +326,9 @@ Esto elimina los archivos .lua de Steam\config\stplug-in.</value></data>
   <data name="Fixes_Revert_Failed" xml:space="preserve"><value>No se pudo revertir el parche</value></data>
   <data name="Fixes_Revert_NoManifest" xml:space="preserve"><value>No hay registro de que este parche se haya aplicado. Puede que ya se haya revertido.</value></data>
   <data name="Fixes_Applied_Hint" xml:space="preserve"><value>Este parche ya está aplicado. Revierte para instalar otro.</value></data>
+  <data name="Fixes_MyGames" xml:space="preserve"><value>Mis juegos</value></data>
+  <data name="Fixes_MyGames_Count" xml:space="preserve"><value>{0} de tus juegos tienen parches. Desplázate para ver el resto.</value></data>
+  <data name="Fixes_MyGames_NotInstalled" xml:space="preserve"><value>Aún no hay luas agregadas: añade un juego (o instala uno) para verlo aquí.</value></data>
   <data name="Add_Title" xml:space="preserve"><value>¡A por los Luas™!</value></data>
   <data name="Add_Subtitle" xml:space="preserve"><value>Introduce un App ID, pega un enlace de Steam o busca por nombre de juego</value></data>
   <data name="Add_SearchPlaceholder" xml:space="preserve"><value>Introduce un App ID o busca juegos...</value></data>

--- a/src/LuaToolsGui/Resources/Strings.es.resx
+++ b/src/LuaToolsGui/Resources/Strings.es.resx
@@ -315,6 +315,17 @@ Esto elimina los archivos .lua de Steam\config\stplug-in.</value></data>
   <data name="Fixes_Toast_CouldntApply" xml:space="preserve"><value>No se pudo aplicar el parche</value></data>
   <data name="Fixes_Toast_Refreshed_Title" xml:space="preserve"><value>Actualizado</value></data>
   <data name="Fixes_Toast_Refreshed_Body" xml:space="preserve"><value>{0} juegos con fixes.</value></data>
+  <data name="Fixes_Revert" xml:space="preserve"><value>Revertir</value></data>
+  <data name="Fixes_Revert_Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="Fixes_Revert_Confirm_Title" xml:space="preserve"><value>¿Revertir el parche de {0}?</value></data>
+  <data name="Fixes_Revert_Confirm_Body" xml:space="preserve"><value>¿Revertir "{0}"? Los archivos modificados se restaurarán desde la copia de seguridad y los archivos añadidos por el parche se eliminarán.</value></data>
+  <data name="Fixes_Revert_Done" xml:space="preserve"><value>Parche revertido</value></data>
+  <data name="Fixes_Revert_Done_Body" xml:space="preserve"><value>Se restauraron {0} y se eliminaron {1} archivo(s) añadido(s).</value></data>
+  <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Parche revertido parcialmente</value></data>
+  <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>No se pudieron restaurar {0} archivo(s). Cierra el juego e inténtalo de nuevo.</value></data>
+  <data name="Fixes_Revert_Failed" xml:space="preserve"><value>No se pudo revertir el parche</value></data>
+  <data name="Fixes_Revert_NoManifest" xml:space="preserve"><value>No hay registro de que este parche se haya aplicado. Puede que ya se haya revertido.</value></data>
+  <data name="Fixes_Applied_Hint" xml:space="preserve"><value>Este parche ya está aplicado. Revierte para instalar otro.</value></data>
   <data name="Add_Title" xml:space="preserve"><value>¡A por los Luas™!</value></data>
   <data name="Add_Subtitle" xml:space="preserve"><value>Introduce un App ID, pega un enlace de Steam o busca por nombre de juego</value></data>
   <data name="Add_SearchPlaceholder" xml:space="preserve"><value>Introduce un App ID o busca juegos...</value></data>

--- a/src/LuaToolsGui/Resources/Strings.resx
+++ b/src/LuaToolsGui/Resources/Strings.resx
@@ -360,6 +360,9 @@ This deletes the .lua files from Steam\config\stplug-in.</value></data>
   <data name="Fixes_Revert_Failed" xml:space="preserve"><value>Couldn't revert fix</value></data>
   <data name="Fixes_Revert_NoManifest" xml:space="preserve"><value>No record of this fix being applied. It may already have been reverted.</value></data>
   <data name="Fixes_Applied_Hint" xml:space="preserve"><value>This fix is already applied. Revert it if you want to install another.</value></data>
+  <data name="Fixes_MyGames" xml:space="preserve"><value>My games</value></data>
+  <data name="Fixes_MyGames_Count" xml:space="preserve"><value>{0} of your games have fixes. Scroll the grid to browse the rest.</value></data>
+  <data name="Fixes_MyGames_NotInstalled" xml:space="preserve"><value>No luas added yet — add a game (or install one) to see it here.</value></data>
 
   <!-- ── Add / Download page ── -->
   <data name="Add_Title" xml:space="preserve"><value>Let's get Luing™!</value></data>

--- a/src/LuaToolsGui/Resources/Strings.resx
+++ b/src/LuaToolsGui/Resources/Strings.resx
@@ -349,6 +349,17 @@ This deletes the .lua files from Steam\config\stplug-in.</value></data>
   <data name="Fixes_Toast_CouldntApply" xml:space="preserve"><value>Couldn't apply fix</value></data>
   <data name="Fixes_Toast_Refreshed_Title" xml:space="preserve"><value>Refreshed</value></data>
   <data name="Fixes_Toast_Refreshed_Body" xml:space="preserve"><value>{0} games with fixes.</value></data>
+  <data name="Fixes_Revert" xml:space="preserve"><value>Revert</value></data>
+  <data name="Fixes_Revert_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Fixes_Revert_Confirm_Title" xml:space="preserve"><value>Revert fix for {0}?</value></data>
+  <data name="Fixes_Revert_Confirm_Body" xml:space="preserve"><value>Revert "{0}"? Modified files will be restored from backup and files added by the fix will be deleted.</value></data>
+  <data name="Fixes_Revert_Done" xml:space="preserve"><value>Fix reverted</value></data>
+  <data name="Fixes_Revert_Done_Body" xml:space="preserve"><value>{0} restored, {1} added files removed.</value></data>
+  <data name="Fixes_Revert_Partial" xml:space="preserve"><value>Fix partially reverted</value></data>
+  <data name="Fixes_Revert_Partial_Body" xml:space="preserve"><value>{0} file(s) couldn't be restored. Close the game and try again.</value></data>
+  <data name="Fixes_Revert_Failed" xml:space="preserve"><value>Couldn't revert fix</value></data>
+  <data name="Fixes_Revert_NoManifest" xml:space="preserve"><value>No record of this fix being applied. It may already have been reverted.</value></data>
+  <data name="Fixes_Applied_Hint" xml:space="preserve"><value>This fix is already applied. Revert it if you want to install another.</value></data>
 
   <!-- ── Add / Download page ── -->
   <data name="Add_Title" xml:space="preserve"><value>Let's get Luing™!</value></data>

--- a/src/LuaToolsGui/Services/Downloads/ManifestJobFactory.cs
+++ b/src/LuaToolsGui/Services/Downloads/ManifestJobFactory.cs
@@ -105,7 +105,7 @@ public class ManifestJobFactory(
             },
             (file, _, _) => Task.FromResult(isManifestSlot
                 ? InstallDenuvoManifest(file, appId, gameName)
-                : ApplyDenuvoFix(file, appId, gameName)),
+                : ApplyDenuvoFix(file, appId, fixId, gameName)),
             ConfirmAsync: null,
             OnFinished: onFinished);
     }
@@ -561,8 +561,9 @@ public class ManifestJobFactory(
         }
     }
 
-    /// <summary>Denuvo fix slot: extract into the game folder. Only possible if the game is installed.</summary>
-    private JobResult ApplyDenuvoFix(DownloadedFile file, long appId, string gameName)
+    /// <summary>Denuvo fix slot: extract into the game folder. Only possible if the game is installed.
+    /// Existing files are backed up as .bak inside .luatools-fix/ so the fix can be reverted.</summary>
+    private JobResult ApplyDenuvoFix(DownloadedFile file, long appId, string fixId, string gameName)
     {
         try
         {
@@ -574,21 +575,69 @@ public class ManifestJobFactory(
                 return new JobResult(false, err);
             }
 
-            // Extract into the game folder, overwriting. Best-effort per entry so one locked file
-            // doesn't abandon the rest of the fix.
+            string fixKey = SafeFixKey(fixId);
+            string fixDir = Path.Combine(installDir, FixManifestDir);
+            string backupDir = Path.Combine(fixDir, fixKey);
+            string manifestPath = Path.Combine(fixDir, $"{fixKey}.json");
+            Directory.CreateDirectory(backupDir);
+
+            var manifest = new DenuvoFixManifest
+            {
+                AppId = appId,
+                FixId = fixId,
+                AppliedAt = DateTimeOffset.UtcNow.ToString("o"),
+            };
+
             using var archive = ZipFile.OpenRead(file.FilePath);
             int failed = 0;
             foreach (var entry in archive.Entries)
             {
-                if (string.IsNullOrEmpty(entry.Name)) continue; // directory entry
+                if (string.IsNullOrEmpty(entry.Name)) continue;
                 string dest = Path.Combine(installDir, entry.FullName);
+                string relPath = entry.FullName.Replace('\\', '/');
+
                 try
                 {
+                    if (File.Exists(dest))
+                    {
+                        // Back up the original — never clobber a known-good .bak
+                        string bakRel = $"{fixKey}/{Path.GetFileName(dest)}.bak";
+                        string bakAbs = Path.Combine(installDir, FixManifestDir, bakRel);
+                        if (!File.Exists(bakAbs))
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(bakAbs)!);
+                            File.Copy(dest, bakAbs, overwrite: false);
+                        }
+                        manifest.Files.Add(new DenuvoFixManifestEntry
+                        {
+                            RelativePath = relPath,
+                            Action = "modified",
+                            BackupPath = bakRel,
+                        });
+                    }
+                    else
+                    {
+                        manifest.Files.Add(new DenuvoFixManifestEntry
+                        {
+                            RelativePath = relPath,
+                            Action = "added",
+                        });
+                    }
+
                     Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
                     entry.ExtractToFile(dest, overwrite: true);
                 }
                 catch { failed++; }
             }
+
+            // Write manifest even on partial failure — the backed-up files still need to be recoverable.
+            try
+            {
+                string json = System.Text.Json.JsonSerializer.Serialize(
+                    manifest, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(manifestPath, json);
+            }
+            catch { /* best effort */ }
 
             if (failed > 0)
             {
@@ -608,7 +657,106 @@ public class ManifestJobFactory(
         }
         finally
         {
-            DeleteStaged(file.FilePath); // archive is disposed by now
+            DeleteStaged(file.FilePath);
+        }
+    }
+
+    // ── Fix revert ──────────────────────────────────────────────────
+
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    internal const string FixManifestDir = ".luatools-fix";
+
+    /// <summary>
+    /// A fix id can carry `/`, `:`, and other characters that are illegal in a Windows path segment
+    /// (e.g. "online-fix:5e01e852-..."). Sanitise it for use as a folder/file name while keeping the
+    /// raw id in the manifest itself.
+    /// </summary>
+    internal static string SafeFixKey(string fixId) =>
+        string.Concat(fixId.Select(ch => Path.GetInvalidFileNameChars().Contains(ch) ? '_' : ch));
+
+    /// <summary>Resolve the manifest path for a given fix inside a game's install folder.</summary>
+    internal static string GetFixManifestPath(string installDir, string fixId) =>
+        Path.Combine(installDir, FixManifestDir, $"{SafeFixKey(fixId)}.json");
+
+    /// <summary>Read a fix manifest from disk, or null if it doesn't exist.</summary>
+    internal static DenuvoFixManifest? ReadFixManifest(string manifestPath)
+    {
+        try
+        {
+            if (!File.Exists(manifestPath)) return null;
+            string json = File.ReadAllText(manifestPath);
+            return System.Text.Json.JsonSerializer.Deserialize<DenuvoFixManifest>(json, JsonOpts);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Revert a previously applied Denuvo fix: restore .bak files for modified entries, delete added
+    /// files, then clean up the backup directory and manifest.
+    /// </summary>
+    public JobResult RevertDenuvoFix(long appId, string fixId, string gameName)
+    {
+        try
+        {
+            string? installDir = library.GetInstallDir(appId);
+            if (installDir is null)
+                return new JobResult(false, string.Format(Resources.Strings.Fixes_Toast_GameNotFound_Body, gameName));
+
+            string manifestPath = GetFixManifestPath(installDir, fixId);
+            var manifest = ReadFixManifest(manifestPath);
+            if (manifest is null)
+                return new JobResult(false, Resources.Strings.Fixes_Revert_NoManifest);
+
+            int restored = 0, deleted = 0, errors = 0;
+
+            foreach (var entry in manifest.Files)
+            {
+                string dest = Path.Combine(installDir, entry.RelativePath);
+                try
+                {
+                    if (entry.Action == "modified" && entry.BackupPath is { } bakRel)
+                    {
+                        string bakAbs = Path.Combine(installDir, FixManifestDir, bakRel);
+                        if (File.Exists(bakAbs))
+                        {
+                            File.Copy(bakAbs, dest, overwrite: true);
+                            File.Delete(bakAbs);
+                            restored++;
+                        }
+                    }
+                    else if (entry.Action == "added")
+                    {
+                        if (File.Exists(dest))
+                        {
+                            File.Delete(dest);
+                            deleted++;
+                        }
+                    }
+                }
+                catch { errors++; }
+            }
+
+            // Clean up backup dir for this fix
+            string backupDir = Path.Combine(installDir, FixManifestDir, SafeFixKey(fixId));
+            try { if (Directory.Exists(backupDir)) Directory.Delete(backupDir, recursive: true); } catch { }
+            try { if (File.Exists(manifestPath)) File.Delete(manifestPath); } catch { }
+
+            if (errors > 0)
+            {
+                string err = string.Format(Resources.Strings.Fixes_Revert_Partial_Body, errors);
+                toast.Show(Resources.Strings.Fixes_Revert_Partial, err, error: true);
+                return new JobResult(false, err);
+            }
+
+            string message = string.Format(Resources.Strings.Fixes_Revert_Done_Body, restored, deleted);
+            toast.Show(Resources.Strings.Fixes_Revert_Done, message);
+            return new JobResult(true, message, installDir);
+        }
+        catch (Exception ex)
+        {
+            toast.Show(Resources.Strings.Fixes_Toast_CouldntApply, ex.Message, error: true);
+            return new JobResult(false, ex.Message);
         }
     }
 

--- a/src/LuaToolsGui/ViewModels/FixesViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/FixesViewModel.cs
@@ -118,11 +118,12 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     private readonly DownloadQueue queue;
     private readonly ManifestJobFactory jobs;
     private readonly SteamLibraryService library;
+    private readonly SteamService steam;
 
     public FixesViewModel(
         LuaToolsApiClient api, AuthService auth, CoverCache covers, ToastService toast,
         SettingsService settings, DownloadQueue queue, ManifestJobFactory jobs,
-        SteamLibraryService library)
+        SteamLibraryService library, SteamService steam)
     {
         this.api = api;
         this.auth = auth;
@@ -132,6 +133,7 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
         this.queue = queue;
         this.jobs = jobs;
         this.library = library;
+        this.steam = steam;
         InitPageSize(settings.FixesPageSize);
     }
 
@@ -157,6 +159,37 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     partial void OnSearchTextChanged(string value) => ApplyFilter();
 
     [ObservableProperty] private string? _selectedTagId; // null = "All"
+
+    // Appids with a lua in Steam's config/stplug-in ("my games"), so the page can filter the fix
+    // listing down to games the user actually owns. Empty when Steam isn't set up / no luas installed.
+    private HashSet<long> _installedAppIds = [];
+
+    /// <summary>True once the listing has been fetched (set at the end of LoadAsync).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanFilter))]
+    private bool _loaded;
+
+    /// <summary>Gates the filter pills ("my games" + tags) behind a finished, non-empty listing.</summary>
+    public bool CanFilter => Loaded && _allGames.Count > 0;
+
+    /// <summary>Only show fix games the user has added (a lua in stplug-in). Mirrors Manage's "my games".</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(MyGamesHint))]
+    private bool _myGamesOnly;
+
+    public string MyGamesHint => _installedAppIds.Count == 0
+        ? Resources.Strings.Fixes_MyGames_NotInstalled
+        : string.Format(Resources.Strings.Fixes_MyGames_Count, _installedAppIds.Count);
+
+    partial void OnMyGamesOnlyChanged(bool value)
+    {
+        if (value)
+        {
+            SelectedTagId = null; // one filter at a time — turning "my games" on drops any tag
+            foreach (var pill in Tags) pill.IsSelected = false;
+        }
+        ApplyFilter();
+    }
 
     // ── Detail flyout ───────────────────────────────────────────────
     [ObservableProperty]
@@ -198,6 +231,14 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
             _allGames = data.Games.Select(g => new FixGameCardVm(g)).ToList();
             Tags.Clear();
             foreach (var t in data.Tags) Tags.Add(new TagPillVm(t));
+
+            // "My games" filter source: the same stplug-in scan the Manage page uses, so the toggle
+            // shows only games the user actually added. Scanned once per listing load.
+            _installedAppIds = steam.StPlugInDir is { } dir
+                ? await Task.Run(() => LuaInstaller.EnumerateInstalled(dir).Select(i => i.AppId).ToHashSet())
+                : [];
+            OnPropertyChanged(nameof(MyGamesHint));
+
             ApplyFilter();
             if (_allGames.Count == 0) EmptyMessage = Resources.Strings.Fixes_Empty_None;
         }
@@ -208,6 +249,7 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
         finally
         {
             IsLoading = false;
+            Loaded = true; // gates the filter pills: they appear only once the listing settled
         }
     }
 
@@ -216,6 +258,7 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     {
         if (SearchText.Length > 0) SearchText = ""; // reset filter → full list visible
         if (SelectedTagId is not null) SelectTag(SelectedTagId); // clear active tag (toggles off)
+        if (MyGamesOnly) MyGamesOnly = false; // ditto for the "my games" filter
         await LoadAsync(force: true);
         toast.Show(Resources.Strings.Fixes_Toast_Refreshed_Title,
             string.Format(Resources.Strings.Fixes_Toast_Refreshed_Body, _allGames.Count));
@@ -225,6 +268,7 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     private void SelectTag(string? tagId)
     {
         SelectedTagId = SelectedTagId == tagId ? null : tagId; // toggle off when re-clicked
+        if (MyGamesOnly) MyGamesOnly = false; // one filter at a time — picking a tag drops "my games"
         foreach (var pill in Tags) pill.IsSelected = pill.Id == SelectedTagId;
         ApplyFilter();
     }
@@ -234,6 +278,7 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
         string q = SearchText.Trim();
         IEnumerable<FixGameCardVm> shown = _allGames;
         if (SelectedTagId is { } tag) shown = shown.Where(g => g.TagIds.Contains(tag));
+        if (MyGamesOnly) shown = shown.Where(g => long.TryParse(g.AppId, out long id) && _installedAppIds.Contains(id));
         if (q.Length > 0) shown = shown.Where(g => g.Matches(q));
 
         // Hand the filtered list to the base: it slices the visible page and (via OnPageSliced) warms

--- a/src/LuaToolsGui/ViewModels/FixesViewModel.cs
+++ b/src/LuaToolsGui/ViewModels/FixesViewModel.cs
@@ -79,14 +79,25 @@ public partial class FixItemVm(DenuvoFix f) : ObservableObject
     /// </summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanDownloadFix), nameof(FixHint))]
+
     private bool _gameInstalled;
 
+    /// <summary>True when the fix has been applied (its revert manifest exists on disk). Drives the Revert button.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasApplied), nameof(CanDownloadFix), nameof(FixHint))]
+    private bool _isApplied;
+
+    public bool HasApplied => IsApplied;
+
     public bool CanDownloadManifest => HasManifest && ManifestItem?.IsActive != true;
-    public bool CanDownloadFix => HasFix && GameInstalled && FixItem?.IsActive != true;
+    public bool CanDownloadFix => HasFix && GameInstalled && !IsApplied && FixItem?.IsActive != true;
 
     /// <summary>Why the Fix button is greyed out, or null when it isn't. A null ToolTip shows nothing,
     /// so this doubles as the "should there be a tooltip at all" test.</summary>
-    public string? FixHint => GameInstalled ? null : Resources.Strings.Fixes_NotInstalled_Hint;
+    public string? FixHint =>
+        IsApplied ? Resources.Strings.Fixes_Applied_Hint
+        : GameInstalled ? null
+        : Resources.Strings.Fixes_NotInstalled_Hint;
 
     private static string FormatDate(string? iso) =>
         DateTimeOffset.TryParse(iso, out var d) ? d.UtcDateTime.ToString("d MMM yyyy") : "";
@@ -297,9 +308,16 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
 
                 // Is the game on disk? GetInstallDir walks libraryfolders.vdf + appmanifest_*.acf, so
                 // it's file I/O — off the UI thread. Resolved once here rather than per fix row.
-                bool installed = long.TryParse(game.AppId, out long gameAppId)
-                    && await Task.Run(() => library.GetInstallDir(gameAppId) is not null);
-                foreach (var f in _allFixes) f.GameInstalled = installed;
+                string? installDir = long.TryParse(game.AppId, out long gameAppId)
+                    ? await Task.Run(() => library.GetInstallDir(gameAppId))
+                    : null;
+                foreach (var f in _allFixes)
+                {
+                    f.GameInstalled = installDir is not null;
+                    // Whether this specific fix has been applied (revert manifest on disk).
+                    f.IsApplied = installDir is not null
+                        && File.Exists(ManifestJobFactory.GetFixManifestPath(installDir, f.Id));
+                }
 
                 // Build the per-game filter pills from the distinct tags across this game's fixes.
                 // But only when there's more than one (a single tag is no filter).
@@ -344,6 +362,48 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
     [RelayCommand]
     private Task DownloadFix(FixItemVm fix) => RunDownload(fix, "fix");
 
+    /// <summary>Confirm, then revert an applied fix back to its original files.</summary>
+    [RelayCommand]
+    private void RevertFix(FixItemVm fix)
+    {
+        if (SelectedGame is not { } game) return;
+        _pendingRevert = (fix, game);
+        ConfirmRevertTitle = string.Format(Resources.Strings.Fixes_Revert_Confirm_Title, game.Name);
+        ConfirmRevertBody = string.Format(Resources.Strings.Fixes_Revert_Confirm_Body, game.Name);
+        IsConfirmingRevert = true;
+    }
+
+    [RelayCommand]
+    private void CancelRevertConfirm()
+    {
+        IsConfirmingRevert = false;
+        _pendingRevert = null;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmRevert()
+    {
+        IsConfirmingRevert = false;
+        var pending = _pendingRevert;
+        _pendingRevert = null;
+        if (pending is not (var fix, var game)) return;
+        if (!long.TryParse(game.AppId, out long appId)) return;
+
+        var result = await Task.Run(() => jobs.RevertDenuvoFix(appId, fix.Id, game.Name));
+        if (!result.Ok)
+        {
+            toast.Show(Resources.Strings.Fixes_Revert_Failed, result.Message ?? "", error: true);
+            return;
+        }
+
+        fix.IsApplied = false;
+    }
+
+    private (FixItemVm Fix, FixGameCardVm Game)? _pendingRevert;
+    [ObservableProperty] private bool _isConfirmingRevert;
+    [ObservableProperty] private string _confirmRevertTitle = "";
+    [ObservableProperty] private string _confirmRevertBody = "";
+
     /// <summary>
     /// Queue one slot of a fix. The download, install and result toast all happen in the shared queue,
     /// so this returns as soon as the item is enqueued.
@@ -374,8 +434,15 @@ public partial class FixesViewModel : PagedListViewModel<FixGameCardVm>
                 // The factory already toasts success and install failures. A download that never got
                 // that far (network, auth, daily limit) still needs to say something.
                 if (result is null && item.Status == DownloadStatus.Failed)
+                {
                     toast.Show(Resources.Strings.Fixes_Toast_DownloadFailed,
                         item.Message ?? Resources.Strings.Fixes_Toast_DownloadFailed_Body, error: true);
+                    return;
+                }
+
+                // A successfully applied fix unlocks the Revert button right away, without closing and
+                // reopening the flyout.
+                if (slot == "fix" && result?.Ok == true) fix.IsApplied = true;
             });
 
         var item = queue.Enqueue(job);

--- a/src/LuaToolsGui/Views/FixesView.xaml
+++ b/src/LuaToolsGui/Views/FixesView.xaml
@@ -329,12 +329,13 @@
                 Background="#1c1c22"
                 BorderBrush="#22FFFFFF"
                 BorderThickness="1,0,0,0">
-                <Grid Margin="20" DataContext="{Binding SelectedGame}">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="Auto" />
+                <Grid>
+                    <Grid Margin="20" DataContext="{Binding SelectedGame}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <!-- Close -->
@@ -487,9 +488,10 @@
                                                 </markdig:MarkdownViewer>
 
                                                 <!-- Download buttons -->
-                                                <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                                                <StackPanel Margin="0,14,0,0" Orientation="Horizontal">
                                                     <ui:Button
-                                                        Margin="0,0,8,0"
+                                                        Margin="0,0,10,0"
+                                                        Padding="14,7"
                                                         Command="{Binding DataContext.DownloadManifestCommand, ElementName=Root}"
                                                         CommandParameter="{Binding}"
                                                         Content="{x:Static res:Strings.Fixes_Manifest}"
@@ -497,6 +499,8 @@
                                                         IsEnabled="{Binding CanDownloadManifest}"
                                                         Visibility="{Binding HasManifest, Converter={StaticResource BoolToVis}}" />
                                                     <ui:Button
+                                                        Margin="0,0,10,0"
+                                                        Padding="14,7"
                                                         Appearance="Primary"
                                                         Command="{Binding DataContext.DownloadFixCommand, ElementName=Root}"
                                                         CommandParameter="{Binding}"
@@ -506,6 +510,14 @@
                                                         ToolTip="{Binding FixHint}"
                                                         ToolTipService.ShowOnDisabled="True"
                                                         Visibility="{Binding HasFix, Converter={StaticResource BoolToVis}}" />
+                                                    <ui:Button
+                                                        Margin="0,0,10,0"
+                                                        Padding="14,7"
+                                                        Command="{Binding DataContext.RevertFixCommand, ElementName=Root}"
+                                                        CommandParameter="{Binding}"
+                                                        Content="{x:Static res:Strings.Fixes_Revert}"
+                                                        Icon="{ui:SymbolIcon ArrowClockwise24}"
+                                                        Visibility="{Binding IsApplied, Converter={StaticResource BoolToVis}}" />
                                                 </StackPanel>
 
                                                 <!--  Per-slot progress, bound straight to the queue item.  -->
@@ -530,6 +542,53 @@
                             </ItemsControl>
                         </StackPanel>
                     </ScrollViewer>
+                    </Grid>
+
+                    <!-- Revert confirmation overlay (in-flyout card, same pattern as ModeView). -->
+                    <Grid
+                        Background="#99000000"
+                        Visibility="{Binding IsConfirmingRevert, Converter={StaticResource BoolToVis}}">
+                        <Border
+                            MaxWidth="360"
+                            Margin="16"
+                            Padding="20"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Background="#1c1c22"
+                            BorderBrush="#33FFFFFF"
+                            BorderThickness="1"
+                            CornerRadius="12">
+                            <StackPanel>
+                                <TextBlock
+                                    FontSize="16"
+                                    FontWeight="Bold"
+                                    Text="{Binding ConfirmRevertTitle}"
+                                    TextWrapping="Wrap" />
+                                <TextBlock
+                                    Margin="0,8,0,0"
+                                    FontSize="12.5"
+                                    Foreground="#9ca3af"
+                                    Text="{Binding ConfirmRevertBody}"
+                                    TextWrapping="Wrap" />
+                                <StackPanel
+                                    Margin="0,18,0,0"
+                                    HorizontalAlignment="Right"
+                                    Orientation="Horizontal">
+                                    <ui:Button
+                                        Margin="0,0,10,0"
+                                        Padding="14,7"
+                                        Command="{Binding CancelRevertConfirmCommand}"
+                                        Content="{x:Static res:Strings.Fixes_Revert_Cancel}" />
+                                    <ui:Button
+                                        Padding="14,7"
+                                        Appearance="Primary"
+                                        Command="{Binding ConfirmRevertCommand}"
+                                        Content="{x:Static res:Strings.Fixes_Revert}"
+                                        Icon="{ui:SymbolIcon ArrowClockwise24}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
                 </Grid>
             </Border>
         </Grid>

--- a/src/LuaToolsGui/Views/FixesView.xaml
+++ b/src/LuaToolsGui/Views/FixesView.xaml
@@ -55,53 +55,95 @@
             PlaceholderText="{x:Static res:Strings.Common_SearchPlaceholder}"
             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
 
-        <!-- Tag filter pills -->
-        <ItemsControl Grid.Row="2" Margin="0,12,0,0" ItemsSource="{Binding Tags}">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <WrapPanel Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Button
-                        Margin="0,0,6,6"
-                        Command="{Binding DataContext.SelectTagCommand, ElementName=Root}"
-                        CommandParameter="{Binding Id}"
-                        Cursor="Hand">
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border
-                                    x:Name="Pill"
-                                    Padding="10,4"
-                                    Background="#14a78bfa"
-                                    BorderBrush="#40a78bfa"
-                                    BorderThickness="1"
-                                    CornerRadius="6">
-                                    <TextBlock
-                                        x:Name="PillText"
-                                        FontSize="11.5"
-                                        FontWeight="SemiBold"
-                                        Foreground="#a78bfa"
-                                        Text="{Binding Name}" />
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <!-- Active: filled accent. -->
-                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                        <Setter TargetName="Pill" Property="Background" Value="#a78bfa" />
-                                        <Setter TargetName="Pill" Property="BorderBrush" Value="#a78bfa" />
-                                        <Setter TargetName="PillText" Property="Foreground" Value="#ffffff" />
-                                    </DataTrigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Pill" Property="Background" Value="#28a78bfa" />
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <!-- "My games" toggle + tag filter pills (shown once the listing is loaded and non-empty) -->
+        <StackPanel
+            Grid.Row="2"
+            Margin="0,12,0,0"
+            Orientation="Horizontal"
+            Visibility="{Binding CanFilter, Converter={StaticResource BoolToVis}}">
+            <ToggleButton
+                Margin="0,0,8,6"
+                Cursor="Hand"
+                Foreground="#a78bfa"
+                IsChecked="{Binding MyGamesOnly}"
+                ToolTip="{Binding MyGamesHint}">
+                <ToggleButton.Template>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border
+                            x:Name="Pill"
+                            Padding="10,4"
+                            Background="#14a78bfa"
+                            BorderBrush="#40a78bfa"
+                            BorderThickness="1"
+                            CornerRadius="6">
+                            <TextBlock
+                                x:Name="PillText"
+                                FontSize="11.5"
+                                FontWeight="SemiBold"
+                                Foreground="#a78bfa"
+                                Text="{x:Static res:Strings.Fixes_MyGames}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <!-- Active: filled accent, exactly like a selected tag pill. -->
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Pill" Property="Background" Value="#a78bfa" />
+                                <Setter TargetName="Pill" Property="BorderBrush" Value="#a78bfa" />
+                                <Setter TargetName="PillText" Property="Foreground" Value="#ffffff" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Pill" Property="Background" Value="#28a78bfa" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </ToggleButton.Template>
+            </ToggleButton>
+            <ItemsControl ItemsSource="{Binding Tags}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button
+                            Margin="0,0,6,6"
+                            Command="{Binding DataContext.SelectTagCommand, ElementName=Root}"
+                            CommandParameter="{Binding Id}"
+                            Cursor="Hand">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border
+                                        x:Name="Pill"
+                                        Padding="10,4"
+                                        Background="#14a78bfa"
+                                        BorderBrush="#40a78bfa"
+                                        BorderThickness="1"
+                                        CornerRadius="6">
+                                        <TextBlock
+                                            x:Name="PillText"
+                                            FontSize="11.5"
+                                            FontWeight="SemiBold"
+                                            Foreground="#a78bfa"
+                                            Text="{Binding Name}" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <!-- Active: filled accent. -->
+                                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                            <Setter TargetName="Pill" Property="Background" Value="#a78bfa" />
+                                            <Setter TargetName="Pill" Property="BorderBrush" Value="#a78bfa" />
+                                            <Setter TargetName="PillText" Property="Foreground" Value="#ffffff" />
+                                        </DataTrigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="Pill" Property="Background" Value="#28a78bfa" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
 
         <!-- Loading -->
         <StackPanel


### PR DESCRIPTION
## What
Adds the ability to revert an applied fix back to the original game files.

## How
- Applying a fix now backups already-existing files as `.bak` inside `.luatools-fix/` in the game folder, and records every modified/added file in a JSON manifest.
- A new "Revert" button appears next to the fix once applied. Tapping it restores the `.bak` files, deletes the files the fix added, and removes the manifest.
- The manifest is written even if the apply partially fails, so backed-up files stay recoverable.
- UI updates immediately on apply/revert (no flyout reopen needed).
- Confirmation dialog shows the game name; new strings translated to Spanish.
- New "My games" toggle next to the tag pills. It cross-references the fix listing against the luas in Steam's `config/stplug-in` (the same scan the Manage page uses) and shows only those games.
<img width="886" height="539" alt="{57AB661D-8F2C-4D8F-84B9-BF4C74E7A806}" src="https://github.com/user-attachments/assets/5c950aa2-0a09-4346-841f-b944879cd9cb" />

